### PR TITLE
Refactor get/set/add methods in `GFEntity` and `GFComponent`

### DIFF
--- a/cpp/src/component.cpp
+++ b/cpp/src/component.cpp
@@ -66,6 +66,12 @@ void GFComponent::_register_internal() {
 }
 
 void GFComponent::setm(String member, Variant value) {
+	setm_no_notify(member, value);
+
+	ecs_modified_id(get_world()->raw(), get_source_id(), get_id());
+}
+
+void GFComponent::setm_no_notify(String member, Variant value) {
 	ecs_world_t* raw = get_world()->raw();
 
 	// Get member data
@@ -83,9 +89,7 @@ void GFComponent::setm(String member, Variant value) {
 		);
 	}
 
-	// Return member
 	Utils::set_type_from_variant(value, member_data->type, raw, member_ptr);
-	ecs_modified_id(get_world()->raw(), get_source_id(), get_id());
 }
 
 Variant GFComponent::getm(String member) {
@@ -375,6 +379,7 @@ void GFComponent::_bind_methods() {
 
 	godot::ClassDB::bind_method(D_METHOD("getm", "member"), &GFComponent::getm);
 	godot::ClassDB::bind_method(D_METHOD("setm", "member", "value"), &GFComponent::setm);
+	godot::ClassDB::bind_method(D_METHOD("setm_no_notify", "member", "value"), &GFComponent::setm_no_notify);
 
 	godot::ClassDB::bind_method(D_METHOD("get_source_entity"), &GFComponent::get_source_entity);
 	godot::ClassDB::bind_method(D_METHOD("get_source_id"), &GFComponent::get_source_id);

--- a/cpp/src/component.h
+++ b/cpp/src/component.h
@@ -44,6 +44,7 @@ namespace godot {
 
 		Variant getm(String);
 		void setm(String, Variant);
+		void setm_no_notify(String, Variant);
 
 		Ref<GFEntity> get_source_entity();
 		ecs_entity_t get_source_id();

--- a/cpp/src/doc_classes/GFComponent.xml
+++ b/cpp/src/doc_classes/GFComponent.xml
@@ -61,8 +61,8 @@
 				[codeblock]
 				var Vector2C = GFEntity.from("glecs/meta/Vector2")
 				var entity = GFEntity.new()
-				entity.add_component(Vector2C)
-				var vec2 = entity.get_component(Vector2C)
+				entity.add(Vector2C)
+				var vec2 = entity.get(Vector2C)
 
 				vec2.get_source_entity().get_id() == Vector2C.get_id() # True
 				[/codeblock]
@@ -75,8 +75,8 @@
 				[codeblock]
 				var Vector2C = GFEntity.from("glecs/meta/Vector2")
 				var entity = GFEntity.new()
-				entity.add_component(Vector2C)
-				var vec2 = entity.get_component(Vector2C)
+				entity.add(Vector2C)
+				var vec2 = entity.get(Vector2C)
 
 				vec2.get_source_id() == Vector2C.get_id() # True
 				[/codeblock]
@@ -89,8 +89,8 @@
 				Returns the value of a component's member.
 				[codeblock]
 				var entity = GFEntity.new()
-				entity.add_component("glecs/meta/Vector2")
-				var vec2 = entity.get_component("glecs/meta/Vector2")
+				entity.add("glecs/meta/Vector2")
+				var vec2 = entity.get("glecs/meta/Vector2")
 
 				vec2.getm("x")
 				[/codeblock]
@@ -110,10 +110,25 @@
 				Sets the value of a component's member.
 				[codeblock]
 				var entity = GFEntity.new()
-				entity.add_component("glecs/meta/Vector2")
-				var vec2 = entity.get_component("glecs/meta/Vector2")
+				entity.add("glecs/meta/Vector2")
+				var vec2 = entity.get("glecs/meta/Vector2")
 
 				vec2.setm("x", 3.14)
+				[/codeblock]
+			</description>
+		</method>
+		<method name="setm_no_notify">
+			<return type="void" />
+			<param index="0" name="member" type="String" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Sets the value of a component's member without notifying [code]OnSet[/code] observers. Generally, [method setm] should be preferred.
+				[codeblock]
+				var entity = GFEntity.new()
+				entity.add("glecs/meta/Vector2")
+				var vec2 = entity.get("glecs/meta/Vector2")
+
+				vec2.setm_no_nofify("x", 3.14)
 				[/codeblock]
 			</description>
 		</method>

--- a/cpp/src/doc_classes/GFComponentBuilder.xml
+++ b/cpp/src/doc_classes/GFComponentBuilder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GFComponentBuilder" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GFComponentBuilder" inherits="GFEntityBuilder" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		Builder for a new component type.
 	</brief_description>
@@ -30,10 +30,9 @@
 				Creates the new component from the settings of the builder.
 			</description>
 		</method>
-		<method name="is_built">
-			<return type="bool" />
+		<method name="get_member_count">
+			<return type="int" />
 			<description>
-				Returns [code]true[/code] if this builder has already been built.
 			</description>
 		</method>
 		<method name="new_in_world" qualifiers="static">
@@ -41,13 +40,6 @@
 			<param index="0" name="world" type="GFWorld" />
 			<description>
 				Returns a new builder in [param world].
-			</description>
-		</method>
-		<method name="set_name">
-			<return type="GFComponentBuilder" />
-			<param index="0" name="name" type="String" />
-			<description>
-				Sets the name of the new component.
 			</description>
 		</method>
 	</methods>

--- a/cpp/src/doc_classes/GFEntity.xml
+++ b/cpp/src/doc_classes/GFEntity.xml
@@ -10,7 +10,7 @@
 		<link title="More on Flecs Entities">https://www.flecs.dev/flecs/md_docs_2EntitiesComponents.html</link>
 	</tutorials>
 	<methods>
-		<method name="add_component" qualifiers="const vararg">
+		<method name="add" qualifiers="const vararg">
 			<return type="GFEntity" />
 			<param index="0" name="component" type="Variant" />
 			<description>
@@ -18,8 +18,8 @@
 				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
 				[codeblock]
 				var entity:= GFEntity.new()
-				entity.add_component(GFPosition2D, Vector2(10, 10))
-				entity.get_component(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.add(GFPosition2D, Vector2(10, 10))
+				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>
@@ -65,6 +65,14 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="emit">
+			<return type="GFEntity" />
+			<param index="0" name="event" type="Variant" />
+			<param index="1" name="components" type="Array" default="[]" />
+			<param index="2" name="event_members" type="Array" default="[]" />
+			<description>
+			</description>
+		</method>
 		<method name="from" qualifiers="static">
 			<return type="GFEntity" />
 			<param index="0" name="entity" type="Variant" />
@@ -90,7 +98,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="get_component">
+		<method name="get">
 			<return type="GFComponent" />
 			<param index="0" name="component" type="Variant" />
 			<description>
@@ -98,8 +106,8 @@
 				Returns [code]null[/code] if the entity does not have the [param component] attached or if [param component] is not a component. The component is identified by an ID coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
 				[codeblock]
 				var entity:= GFEntity.new()
-				entity.add_component("glecs/meta/Array")
-				entity.get_component("glecs/meta/Array") != null # true
+				entity.add("glecs/meta/Array")
+				entity.get("glecs/meta/Array") != null # true
 				[/codeblock]
 			</description>
 		</method>
@@ -134,8 +142,8 @@
 				Returns [code]null[/code] if the entity does not have the [param component] attached or if [param component] is not a component. The component is identified by an ID coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
 				[codeblock]
 				var entity:= GFEntity.new()
-				entity.add_component("glecs/meta/Array")
-				entity.get_component("glecs/meta/Array") != null # true
+				entity.add("glecs/meta/Array")
+				entity.get("glecs/meta/Array") != null # true
 				[/codeblock]
 			</description>
 		</method>
@@ -218,7 +226,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="set_component" qualifiers="const vararg">
+		<method name="set" qualifiers="const vararg">
 			<return type="GFEntity" />
 			<param index="0" name="component" type="Variant" />
 			<description>
@@ -226,16 +234,15 @@
 				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
 				[codeblock]
 				var entity:= GFEntity.new()
-				entity.add_component(GFPosition2D)
-				entity.set_component(GFPosition2D, Vector2(10, 10))
-				entity.get_component(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.add(GFPosition2D)
+				entity.set(GFPosition2D, Vector2(10, 10))
+				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
 				[/codeblock]
-				If the component is not added yet, then this method will add
-				it automaticly.
+				If the component is not added yet, then this method will add it automaticly.
 				[codeblock]
 				var entity:= GFEntity.new()
-				entity.set_component(GFPosition2D, Vector2(10, 10))
-				entity.get_component(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.set(GFPosition2D, Vector2(10, 10))
+				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>

--- a/cpp/src/doc_classes/GFEntity.xml
+++ b/cpp/src/doc_classes/GFEntity.xml
@@ -260,6 +260,27 @@
 				This method returns [code]self[/code] for chaining.
 			</description>
 		</method>
+		<method name="set_no_notify" qualifiers="const vararg">
+			<return type="GFEntity" />
+			<param index="0" name="component" type="Variant" />
+			<description>
+				Sets component data of type [param component] in this entity without notifying [code]OnSet[/code] observers. Generally, [method set] should be preferred.
+				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
+				[codeblock]
+				var entity:= GFEntity.new()
+				entity.add(GFPosition2D)
+				entity.set(GFPosition2D, Vector2(10, 10))
+				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				[/codeblock]
+				If the component is not added yet, then this method will add it automaticly. Note that [code]OnAdd[/code] observers will still by notified in this scenario.
+				[codeblock]
+				var entity:= GFEntity.new()
+				entity.set(GFPosition2D, Vector2(10, 10))
+				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				[/codeblock]
+				This method returns [code]self[/code] for chaining.
+			</description>
+		</method>
 		<method name="set_pair" qualifiers="const vararg">
 			<return type="GFEntity" />
 			<param index="0" name="first" type="Variant" />

--- a/cpp/src/doc_classes/GFEntityBuilder.xml
+++ b/cpp/src/doc_classes/GFEntityBuilder.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="GFEntityBuilder" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_entity">
+			<return type="GFEntityBuilder" />
+			<param index="0" name="entity" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="add_pair">
+			<return type="GFEntityBuilder" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="build">
+			<return type="GFEntity" />
+			<description>
+			</description>
+		</method>
+		<method name="get_world">
+			<return type="GFWorld" />
+			<description>
+			</description>
+		</method>
+		<method name="new_in_world" qualifiers="static">
+			<return type="GFEntityBuilder" />
+			<param index="0" name="world" type="GFWorld" />
+			<description>
+			</description>
+		</method>
+		<method name="set_name">
+			<return type="GFEntityBuilder" />
+			<param index="0" name="name" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="set_parent">
+			<return type="GFEntityBuilder" />
+			<param index="0" name="parent" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="set_target_entity">
+			<return type="GFEntityBuilder" />
+			<param index="0" name="entity" type="Variant" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/cpp/src/doc_classes/GFModule.xml
+++ b/cpp/src/doc_classes/GFModule.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GFModule" inherits="GFRegisterableEntity"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GFModule" inherits="GFRegisterableEntity" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/cpp/src/doc_classes/GFPair.xml
+++ b/cpp/src/doc_classes/GFPair.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GFPair" inherits="GFEntity"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GFPair" inherits="GFEntity" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		A reference to a pair of entity IDs.
 	</brief_description>

--- a/cpp/src/doc_classes/GFQueryIterator.xml
+++ b/cpp/src/doc_classes/GFQueryIterator.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GFQueryIterator" inherits="RefCounted"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GFQueryIterator" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		An iterator over queried entities.
 	</brief_description>

--- a/cpp/src/doc_classes/GFQuerylikeBuilder.xml
+++ b/cpp/src/doc_classes/GFQuerylikeBuilder.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GFQuerylikeBuilder" inherits="RefCounted"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GFQuerylikeBuilder" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		The abstract base class for different query-like builders.
 	</brief_description>
@@ -49,6 +48,18 @@
 				Marks the last added term write only.
 			</description>
 		</method>
+		<method name="cascade">
+			<return type="GFQuerylikeBuilder" />
+			<param index="0" name="traversal" type="Variant" default="0" />
+			<description>
+			</description>
+		</method>
+		<method name="descend">
+			<return type="GFQuerylikeBuilder" />
+			<param index="0" name="traversal" type="Variant" default="0" />
+			<description>
+			</description>
+		</method>
 		<method name="is_built">
 			<return type="bool" />
 			<description>
@@ -69,6 +80,12 @@
 			<description>
 				Adds a term to the query that matches this or one of the previous terms in an [i]or[/i] chain.
 				The term added is identified by a [Variant] coerced to an ID. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
+			</description>
+		</method>
+		<method name="up">
+			<return type="GFQuerylikeBuilder" />
+			<param index="0" name="traversal" type="Variant" default="0" />
+			<description>
 			</description>
 		</method>
 		<method name="with">

--- a/cpp/src/doc_classes/GFWorld.xml
+++ b/cpp/src/doc_classes/GFWorld.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="GFWorld" inherits="Object"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+<class name="GFWorld" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
 	<brief_description>
 		An entity component system world.
 	</brief_description>

--- a/cpp/src/entity.cpp
+++ b/cpp/src/entity.cpp
@@ -62,12 +62,12 @@ Ref<GFEntity> GFEntity::add_component(
 	}
 	Variant comopnent = members.pop_front();
 
-	_add_component(comopnent, members);
+	add_componentv(comopnent, members);
 
 	return this;
 }
 
-Ref<GFEntity> GFEntity::_add_component(Variant component, Array members) {
+Ref<GFEntity> GFEntity::add_componentv(Variant component, Array members) {
 	GFWorld* w = get_world();
 
 	ecs_entity_t c_id = w->coerce_id(component);
@@ -79,7 +79,7 @@ Ref<GFEntity> GFEntity::_add_component(Variant component, Array members) {
 		)
 	}
 
-	_set_component(c_id, members);
+	set_componentv(c_id, members);
 
 	return this;
 }
@@ -104,11 +104,11 @@ Ref<GFEntity> GFEntity::add_pair(
 	Variant first = members.pop_front();
 	Variant sec = members.pop_front();
 
-	_add_pair(first, sec, members);
+	add_pairv(first, sec, members);
 
 	return this;
 }
-Ref<GFEntity> GFEntity::_add_pair(Variant first, Variant second, Array members) {
+Ref<GFEntity> GFEntity::add_pairv(Variant first, Variant second, Array members) {
 	GFWorld* w = get_world();
 
 	ecs_entity_t first_id = w->coerce_id(first);
@@ -119,7 +119,7 @@ Ref<GFEntity> GFEntity::_add_pair(Variant first, Variant second, Array members) 
 		|| ecs_has_id(w->raw(), pair_id, FLECS_IDEcsComponentID_)
 	) {
 		// Add pair as a component
-		_add_component(pair_id, members);
+		add_componentv(pair_id, members);
 	} else {
 		// Add pair as a dataless tag
 		add_tag(pair_id);
@@ -248,10 +248,10 @@ Ref<GFEntity> GFEntity::set_component(
 	}
 	Variant comopnent = members.pop_front();
 
-	return _set_component(comopnent, members);
+	return set_componentv(comopnent, members);
 }
 
-Ref<GFEntity> GFEntity::_set_component(
+Ref<GFEntity> GFEntity::set_componentv(
 	Variant component,
 	Array members
 ) {
@@ -321,17 +321,17 @@ Ref<GFEntity> GFEntity::set_pair(
 	Variant first = members.pop_front();
 	Variant sec = members.pop_front();
 
-	return _set_pair(first, sec, members);
+	return set_pairv(first, sec, members);
 }
 
-Ref<GFEntity> GFEntity::_set_pair(
+Ref<GFEntity> GFEntity::set_pairv(
 	Variant first,
 	Variant second,
 	Array members
 ) {
 	ecs_entity_t first_id = get_world()->coerce_id(first);
 	ecs_entity_t second_id = get_world()->coerce_id(second);
-	_set_component(ecs_pair(first_id, second_id), members);
+	set_componentv(ecs_pair(first_id, second_id), members);
 
 	return Ref(this);
 }
@@ -443,14 +443,14 @@ void GFEntity::_bind_methods() {
 	{
 		MethodInfo mi;
 		mi.arguments.push_back(PropertyInfo(Variant::NIL, "component"));
-		mi.name = "add_component";
-		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName("add_component"), &GFEntity::add_component, mi);
+		mi.name = "add";
+		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName("add"), &GFEntity::add_component, mi);
 	}
 	{
 		MethodInfo mi;
 		mi.arguments.push_back(PropertyInfo(Variant::NIL, "component"));
-		mi.name = "set_component";
-		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName("set_component"), &GFEntity::set_component, mi);
+		mi.name = "set";
+		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName("set"), &GFEntity::set_component, mi);
 	}
 
 	{
@@ -469,12 +469,11 @@ void GFEntity::_bind_methods() {
 	}
 
 	godot::ClassDB::bind_method(D_METHOD("add_tag", "tag"), &GFEntity::add_tag);
-	godot::ClassDB::bind_method(D_METHOD("get_component", "component"), &GFEntity::get_component);
-	godot::ClassDB::bind_method(D_METHOD("get_pair", "first", "second"), &GFEntity::get_pair);
-
-	godot::ClassDB::bind_method(D_METHOD("emit", "event", "components", "event_members"), &GFEntity::emit, Array(), Array());
 	godot::ClassDB::bind_method(D_METHOD("delete"), &GFEntity::delete_);
+	godot::ClassDB::bind_method(D_METHOD("emit", "event", "components", "event_members"), &GFEntity::emit, Array(), Array());
 
+	godot::ClassDB::bind_method(D_METHOD("get", "component"), &GFEntity::get_component);
+	godot::ClassDB::bind_method(D_METHOD("get_pair", "first", "second"), &GFEntity::get_pair);
 	godot::ClassDB::bind_method(D_METHOD("get_id"), &GFEntity::get_id);
 	godot::ClassDB::bind_method(D_METHOD("get_path"), &GFEntity::get_path);
 	godot::ClassDB::bind_method(D_METHOD("get_world"), &GFEntity::get_world);
@@ -485,7 +484,7 @@ void GFEntity::_bind_methods() {
 
 	godot::ClassDB::bind_method(D_METHOD("pair", "second"), &GFEntity::pair);
 	godot::ClassDB::bind_method(D_METHOD("pair_id", "second_id"), &GFEntity::pair_id);
-	godot::ClassDB::bind_method(D_METHOD("_to_string"), &GFEntity::to_string);
 
+	godot::ClassDB::bind_method(D_METHOD("_to_string"), &GFEntity::to_string);
 	godot::ClassDB::bind_method(D_METHOD("set_name", "name"), &GFEntity::set_name);
 }

--- a/cpp/src/entity.cpp
+++ b/cpp/src/entity.cpp
@@ -256,10 +256,13 @@ Ref<GFEntity> GFEntity::set_componentv(
 	Array members
 ) {
 	ecs_entity_t c_id = get_world()->coerce_id(component);
-	set_component_no_notifyv(c_id, members);
-	ecs_modified_id(get_world()->raw(), get_id(), c_id);
+	Ref<GFEntity> result = set_component_no_notifyv(c_id, members);
+	if (result != nullptr) {
+		ecs_modified_id(get_world()->raw(), get_id(), c_id);
+		return nullptr;
+	}
 
-	return Ref(this);
+	return result;
 }
 
 Ref<GFEntity> GFEntity::set_component_no_notify(
@@ -304,7 +307,7 @@ Ref<GFEntity> GFEntity::set_component_no_notifyv(
 				&& !ecs_has_id(w->raw(), second_id, ecs_id(EcsComponent))
 			) {
 				// ID is not a component, error
-				ERR(Ref(this),
+				ERR(nullptr,
 					"Failed to set data in pair\n",
 					"Neither ID ", first_id,
 					" nor ", second_id, "are components"
@@ -313,7 +316,7 @@ Ref<GFEntity> GFEntity::set_component_no_notifyv(
 
 		} else if (!ecs_has_id(w->raw(), c_id, ecs_id(EcsComponent))) {
 			// Error, passed variant is not a real component
-			ERR(Ref(this),
+			ERR(nullptr,
 				"Failed to add component to entity\n",
 				"ID coerced from ", component, " is not a component"
 			);

--- a/cpp/src/entity.cpp
+++ b/cpp/src/entity.cpp
@@ -255,6 +255,39 @@ Ref<GFEntity> GFEntity::set_componentv(
 	Variant component,
 	Array members
 ) {
+	ecs_entity_t c_id = get_world()->coerce_id(component);
+	set_component_no_notifyv(c_id, members);
+	ecs_modified_id(get_world()->raw(), get_id(), c_id);
+
+	return Ref(this);
+}
+
+Ref<GFEntity> GFEntity::set_component_no_notify(
+	const Variant** args, GDExtensionInt arg_count, GDExtensionCallError &error
+) {
+	if (arg_count < 1) {
+		// Too few arguments, return with error.
+		error.error = GDExtensionCallErrorType::GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
+		error.argument = arg_count;
+		error.expected = 1;
+		return this;
+	}
+
+	// Parse arguments
+	Array members = Array();
+	members.resize(arg_count);
+	for (int i=0; i != arg_count; i++) {
+		members[i] = *args[i];
+	}
+	Variant comopnent = members.pop_front();
+
+	return set_component_no_notifyv(comopnent, members);
+}
+
+Ref<GFEntity> GFEntity::set_component_no_notifyv(
+	Variant component,
+	Array members
+) {
 	GFWorld* w = get_world();
 
 	ecs_entity_t c_id = w->coerce_id(component);
@@ -296,7 +329,7 @@ Ref<GFEntity> GFEntity::set_componentv(
 		c_id,
 		get_world()
 	);
-	ecs_modified_id(w->raw(), get_id(), c_id);
+
 
 	return Ref(this);
 }
@@ -451,6 +484,12 @@ void GFEntity::_bind_methods() {
 		mi.arguments.push_back(PropertyInfo(Variant::NIL, "component"));
 		mi.name = "set";
 		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName("set"), &GFEntity::set_component, mi);
+	}
+	{
+		MethodInfo mi;
+		mi.arguments.push_back(PropertyInfo(Variant::NIL, "component"));
+		mi.name = "set_no_notify";
+		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName("set_no_notify"), &GFEntity::set_component_no_notify, mi);
 	}
 
 	{

--- a/cpp/src/entity.h
+++ b/cpp/src/entity.h
@@ -68,6 +68,8 @@ namespace godot {
 
 		Ref<GFEntity> set_component(const Variant**, GDExtensionInt, GDExtensionCallError&);
 		Ref<GFEntity> set_componentv(Variant, Array);
+		Ref<GFEntity> set_component_no_notify(const Variant**, GDExtensionInt, GDExtensionCallError&);
+		Ref<GFEntity> set_component_no_notifyv(Variant, Array);
 		Ref<GFEntity> set_name(String);
 		Ref<GFEntity> set_pair(const Variant**, GDExtensionInt, GDExtensionCallError&);
 		Ref<GFEntity> set_pairv(Variant, Variant, Array);

--- a/cpp/src/entity.h
+++ b/cpp/src/entity.h
@@ -45,36 +45,32 @@ namespace godot {
 		static Ref<GFEntity> from_id(ecs_entity_t, GFWorld*);
 
 		Ref<GFEntity> add_component(const Variant**, GDExtensionInt, GDExtensionCallError&);
-		Ref<GFEntity> _add_component(Variant, Array);
-		Ref<GFEntity> set_component(const Variant**, GDExtensionInt, GDExtensionCallError&);
-		Ref<GFEntity> _set_component(Variant, Array);
-
+		Ref<GFEntity> add_componentv(Variant, Array);
 		Ref<GFEntity> add_pair(const Variant**, GDExtensionInt, GDExtensionCallError&);
-		Ref<GFEntity> _add_pair(Variant, Variant, Array);
-		Ref<GFEntity> set_pair(const Variant**, GDExtensionInt, GDExtensionCallError&);
-		Ref<GFEntity> _set_pair(Variant, Variant, Array);
-
+		Ref<GFEntity> add_pairv(Variant, Variant, Array);
 		Ref<GFEntity> add_tag(Variant);
 
+		void delete_();
 		Ref<GFEntity> emit(Variant, Array, Array);
 
 		Ref<GFComponent> get_component(Variant);
-		Ref<GFComponent> get_pair(Variant, Variant);
-
-		void delete_();
-
 		ecs_entity_t get_id();
+		String get_name();
+		Ref<GFComponent> get_pair(Variant, Variant);
 		String get_path();
 		GFWorld* get_world();
 
 		bool is_alive();
 		bool is_pair();
 
-		Ref<GFEntity> set_name(String);
-		String get_name();
-
 		Ref<GFPair> pair(Variant second);
 		ecs_entity_t pair_id(ecs_entity_t second_id);
+
+		Ref<GFEntity> set_component(const Variant**, GDExtensionInt, GDExtensionCallError&);
+		Ref<GFEntity> set_componentv(Variant, Array);
+		Ref<GFEntity> set_name(String);
+		Ref<GFEntity> set_pair(const Variant**, GDExtensionInt, GDExtensionCallError&);
+		Ref<GFEntity> set_pairv(Variant, Variant, Array);
 
 		String to_string();
 

--- a/unittests/test_components.gd
+++ b/unittests/test_components.gd
@@ -21,13 +21,13 @@ func test_add_entity():
 func test_world_deletion():
 	var w:= GFWorld.new()
 	var e:= GFEntity.new_in_world(w) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
-	var foo:= e.get_component(Foo)
+	var foo:= e.get(Foo)
 	var e2:= GFEntity.new_in_world(w) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
-	var foo2:= e2.get_component(Foo)
+	var foo2:= e2.get(Foo)
 
 	foo.set_value(Vector2(24.3, 2.1))
 	foo2.set_value(Vector2(125.1, 3.3))
@@ -50,19 +50,19 @@ func test_registration():
 	var w:= world
 
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(RegistrationA) \
-		.add_component(RegistrationB) \
+		.add(RegistrationA) \
+		.add(RegistrationB) \
 		.set_name("Test")
 
-	e.get_component(RegistrationA).set_value(3)
-	e.get_component(RegistrationB).set_value(11)
+	e.get(RegistrationA).set_value(3)
+	e.get(RegistrationB).set_value(11)
 
 	# A system defined in RegistrationA's _registered function should run
 	# on GFWorld's process pipeline
 	w.progress(0.0)
 
-	assert_almost_eq(e.get_component(RegistrationA).get_result(), 14.0, .001)
-	assert_almost_eq(e.get_component(RegistrationB).get_result(), 33.0, .001)
+	assert_almost_eq(e.get(RegistrationA).get_result(), 14.0, .001)
+	assert_almost_eq(e.get(RegistrationB).get_result(), 33.0, .001)
 
 
 func test_simple_system():
@@ -73,12 +73,12 @@ func test_simple_system():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
 
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(Foo).get_value(), Vector2(2, 5))
+	assert_eq(entity.get(Foo).get_value(), Vector2(2, 5))
 
 
 # test components components_in_relationships
@@ -87,12 +87,12 @@ func test_components_in_relationships():
 
 	var e:= GFEntity.new_in_world(w)
 	var foo:Foo = e.add_pair(Targets, Foo) \
-		.get_component(w.pair(Targets, Foo))
+		.get(w.pair(Targets, Foo))
 
 	foo.set_value(Vector2(54, 6))
 	assert_almost_eq(foo.get_value(), Vector2(54, 6), Vector2(.001, .001))
 
-	foo = e.get_component(w.pair(Targets, Foo))
+	foo = e.get(w.pair(Targets, Foo))
 	assert_almost_eq(foo.get_value(), Vector2(54, 6), Vector2(.001, .001))
 
 	w.free()

--- a/unittests/test_ecs_world.gd
+++ b/unittests/test_ecs_world.gd
@@ -33,14 +33,14 @@ func test_world_deletion():
 	var w:= GFWorld.new()
 
 	var e:= GFEntity.new_in_world(w) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
-	var foo:Foo = e.get_component(Foo)
+	var foo:Foo = e.get(Foo)
 
 	var e2:= GFEntity.new_in_world(w) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
-	var foo2:Foo = e2.get_component(Foo)
+	var foo2:Foo = e2.get(Foo)
 
 	foo.setm(&"vec", 24.3)
 	foo2.setm(&"vec", 125.1)
@@ -75,12 +75,12 @@ func test_simple_system():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
 
 	world.progress(0.0)
 
-	assert_almost_eq(entity.get_component(Foo).getm(&"vec"), 2.67, 0.01)
+	assert_almost_eq(entity.get(Foo).getm(&"vec"), 2.67, 0.01)
 
 class Foo extends GFComponent:
 	func _build(b: GFComponentBuilder) -> void:

--- a/unittests/test_entities.gd
+++ b/unittests/test_entities.gd
@@ -13,10 +13,10 @@ func after_all():
 
 func test_component_get_and_set():
 	var e:GFEntity = GFEntity.new_in_world(world) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
 
-	var foo:Foo = e.get_component(Foo)
+	var foo:Foo = e.get(Foo)
 	assert_almost_eq(foo.value, 0.0, 0.01)
 
 	foo.value = 2.3
@@ -26,10 +26,10 @@ func test_component_get_and_set():
 
 func test_component_string_get_and_set():
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(Stringy) \
+		.add(Stringy) \
 		.set_name("Test")
 
-	var foo:Stringy = e.get_component(Stringy)
+	var foo:Stringy = e.get(Stringy)
 	foo.a = "po"
 	foo.b = "em"
 	assert_eq(foo.a, "po")
@@ -41,9 +41,9 @@ func test_component_string_get_and_set():
 
 func test_new_entity_with_unregistered_component():
 	var e:GFEntity = GFEntity.new_in_world(world) \
-		.add_component(Unregistered) \
+		.add(Unregistered) \
 		.set_name("Test")
-	assert_eq(e.get_component(Unregistered).value, 0)
+	assert_eq(e.get(Unregistered).value, 0)
 
 func test_creating_entity_by_new():
 	# Test that an entity is invalidated by being deleted
@@ -90,19 +90,19 @@ func test_builder():
 		.add_pair(Foo, Stringy) \
 		.add_pair(Stringy, Foo) \
 		.build()
-	
+
 	assert_eq(e.get_name(), "Built", "Expected entity to be named 'Built'")
-	
+
 	var query:GFQuery = GFQueryBuilder.new_in_world(world) \
 		.with(Foo) \
 		.with(world.pair(Foo, Stringy)) \
 		.with(world.pair(Stringy, Foo)) \
 		.build()
-	
+
 	var i:= 0
 	for _x in query.iterate():
 		i += 1
-	
+
 	assert_eq(i, 1, "Expected query to find the built entity")
 
 #endregion

--- a/unittests/test_errors.gd
+++ b/unittests/test_errors.gd
@@ -13,16 +13,16 @@ func after_all():
 
 func test_get_nonexistant_property():
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Foo) \
+		.add(Foo) \
 		.set_name("Test")
-	var foo:Foo = entity.get_component(Foo)
+	var foo:Foo = entity.get(Foo)
 
 	assert_eq(foo.getm(&"not a real property"), null)
 
 
 func test_new_entity_with_unregistered_component():
 	var _entity:= GFEntity.new_in_world(world) \
-		.add_component(Unregistered) \
+		.add(Unregistered) \
 		.set_name("Test")
 
 	# We can't assert the right error is thrown, but it should be fine as

--- a/unittests/test_events.gd
+++ b/unittests/test_events.gd
@@ -22,7 +22,7 @@ func test_on_add_event():
 			)
 
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(Ints) \
+		.add(Ints) \
 		.set_name("WithInts")
 	var e2:= GFEntity.new_in_world(world) \
 		.set_name("WithoutInts")
@@ -31,7 +31,7 @@ func test_on_add_event():
 	var e4:= GFEntity.new_in_world(world) \
 		.set_name("WithoutInts")
 
-	e3.add_component(Ints)
+	e3.add(Ints)
 
 	assert_eq(data.i, 2)
 
@@ -51,7 +51,7 @@ func test_on_set_event():
 			)
 
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(Ints, 2, 31) \
+		.add(Ints, 2, 31) \
 		.set_name("WithInts")
 	var e2:= GFEntity.new_in_world(world) \
 		.set_name("WithoutInts")
@@ -60,7 +60,7 @@ func test_on_set_event():
 	var e4:= GFEntity.new_in_world(world) \
 		.set_name("WithoutInts")
 
-	e3.add_component(Ints, 99, 2)
+	e3.add(Ints, 99, 2)
 
 	assert_eq(data.i, 2 + 31 + 99 + 2)
 
@@ -69,6 +69,25 @@ func test_on_set_event():
 	e3.delete()
 	e4.delete()
 
+
+func test_on_set_event_setm():
+	var data:= {i=0}
+	GFObserverBuilder.new_in_world(world) \
+		.set_events("flecs/core/OnSet") \
+		.with(Ints) \
+		.for_each(func(ints: Ints):
+			data.i += 1
+			)
+
+	var e:= GFEntity.new_in_world(world) \
+		.set_name("WithInts") \
+		.add(Ints, 2, 31)
+	
+	assert_eq(data.i, 1, "Expected `OnSet` observer to have run once from being added")
+	e.get(Ints).setm_no_notify("a", 3)
+	assert_eq(data.i, 1, "Expected `OnSet` observer to have been only run once after calling setm_no_notify")
+	e.get(Ints).setm("a", 4)
+	assert_eq(data.i, 2, "Expected `OnSet` observer to have run a 2nd time after setm")
 
 func test_on_add_event_with_objects():
 	var data:= {i=0}
@@ -80,10 +99,10 @@ func test_on_add_event_with_objects():
 			)
 
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(Textures) \
+		.add(Textures) \
 		.set_name("WithInts")
 	assert_eq(data.i, 1)
-	assert_eq(e.get_component(Textures).a, null)
+	assert_eq(e.get(Textures).a, null)
 
 	e.delete()
 
@@ -92,16 +111,16 @@ func test_on_add_event_with_objects():
 	data.i = 0
 	var e2:= GFEntity.new_in_world(world) \
 		.set_name("WithTextures")
-	e2.add_component(Textures, load("res://icon.png"))
+	e2.add(Textures, load("res://icon.png"))
 	assert_eq(data.i, 1)
-	assert_eq(e2.get_component(Textures).a, load("res://icon.png"))
+	assert_eq(e2.get(Textures).a, load("res://icon.png"))
 
 	e2.delete()
 
 func test_user_signal() -> void:
 	var Update = GFEntity.new_in_world(world) \
 		.set_name("Update")
-	
+
 	var data:= {i = 0}
 	GFObserverBuilder.new_in_world(world) \
 		.set_events(Update) \
@@ -109,15 +128,15 @@ func test_user_signal() -> void:
 		.for_each(func(ints:Ints):
 			data.i += 1
 			)
-	
+
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(Ints)
+		.add(Ints)
 	# Observer shouldn't match against this entity
 	var e2:= GFEntity.new_in_world(world) \
-		.add_component(Ints)
-	
+		.add(Ints)
+
 	Update.emit(e, [Ints])
-	
+
 	assert_eq(data.i, 1, "Expected observer to match an `Update` event once")
 
 #endregion

--- a/unittests/test_prefab.gd
+++ b/unittests/test_prefab.gd
@@ -32,8 +32,8 @@ func test_prefab():
 	entity.add_tag(pair)
 
 	# Test inhereted components exist entity
-	var foo:Foo = entity.get_component(Foo)
-	var bar:Bar = entity.get_component(Bar)
+	var foo:Foo = entity.get(Foo)
+	var bar:Bar = entity.get(Bar)
 	assert_ne(foo, null)
 	assert_ne(bar, null)
 
@@ -84,7 +84,7 @@ class Bar extends GFComponent:
 class MyPrefab extends GFRegisterableEntity:
 	func _register(_world:GFWorld) -> void:
 		add_tag("flecs/core/Prefab")
-		add_component(Foo, true, 23, 2.33)
-		add_component(Bar, Vector2(2, 1.1), 5.6)
+		add(Foo, true, 23, 2.33)
+		add(Bar, Vector2(2, 1.1), 5.6)
 
 #endregion

--- a/unittests/test_queries.gd
+++ b/unittests/test_queries.gd
@@ -23,17 +23,17 @@ func test_optional_terms():
 
 	var empty:= GFEntity.new_in_world(w) \
 		.set_name("Empty") \
-		.add_component(Bools)
+		.add(Bools)
 	var just_ints:= GFEntity.new_in_world(w) \
 		.set_name("JustInts") \
-		.add_component(Ints)
+		.add(Ints)
 	var just_bools:= GFEntity.new_in_world(w) \
 		.set_name("JustBools") \
-		.add_component(Bools)
+		.add(Bools)
 	var all:= GFEntity.new_in_world(w) \
 		.set_name("All") \
-		.add_component(Ints) \
-		.add_component(Bools)
+		.add(Ints) \
+		.add(Bools)
 
 	data.ints = 0
 	data.bools = 0
@@ -68,11 +68,11 @@ func test_or_operation_terms():
 				data.bools += 1
 			)
 
-	GFEntity.new_in_world(w).add_component(Ints)
-	GFEntity.new_in_world(w).add_component(Ints)
-	GFEntity.new_in_world(w).add_component(Ints)
-	GFEntity.new_in_world(w).add_component(Bools)
-	GFEntity.new_in_world(w).add_component(Ints).add_component(Bools)
+	GFEntity.new_in_world(w).add(Ints)
+	GFEntity.new_in_world(w).add(Ints)
+	GFEntity.new_in_world(w).add(Ints)
+	GFEntity.new_in_world(w).add(Bools)
+	GFEntity.new_in_world(w).add(Ints).add(Bools)
 
 	w.progress(0.0)
 
@@ -83,17 +83,17 @@ func test_or_operation_terms():
 func test_up_traversal():
 	var par:= GFEntity.new_in_world(world) \
 		.set_name("Parent") \
-		.add_component(Bools)
+		.add(Bools)
 	var child:= GFEntity.new_in_world(world) \
 		.set_name("Child") \
-		.add_component(Bools) \
+		.add(Bools) \
 		.add_pair("flecs/core/ChildOf", par)
 
 	var parent_descriptions:GFQuery = GFQueryBuilder.new_in_world(world) \
 		.with(Bools).up() \
 		.with(Bools) \
 		.build()
-	
+
 	var i:= 0
 	for desc in parent_descriptions.iterate():
 		assert_true(desc[0].get_source_id() == par.get_id(), "Expecteded 1st item to be the parent")

--- a/unittests/test_registration.gd
+++ b/unittests/test_registration.gd
@@ -18,7 +18,7 @@ func after_all():
 
 func test_auto_register_script():
 	GFEntity.new_in_world(world) \
-		.add_component(AComponent)
+		.add(AComponent)
 
 	assert_ne(
 		world.lookup(

--- a/unittests/test_relations.gd
+++ b/unittests/test_relations.gd
@@ -14,19 +14,19 @@ func after_each():
 func test_add_and_set_pairs() -> void:
 	var eats:= GFEntity.new_in_world(world).set_name("Eats")
 	var grass:= GFEntity.new_in_world(world).set_name("Grass")
-	
+
 	var e:= GFEntity.new_in_world(world)
-	
+
 	e.add_pair("Eats", GFRotation2D, 3.0)
 	assert_almost_eq(
-		e.get_component(eats.pair(GFRotation2D)).get_angle(),
+		e.get(eats.pair(GFRotation2D)).get_angle(),
 		3.0,
 		0.01,
 	)
-	
+
 	e.set_pair(eats, GFRotation2D, 1.5)
 	e.add_pair(GFRotation2D, eats, 1.1)
-	
+
 	assert_almost_eq(
 		e.get_pair(eats, GFRotation2D).get_angle(),
 		1.5,
@@ -60,7 +60,7 @@ func test_basic_query():
 	for _x in grass_eater_iter.iterate():
 		grass_eater_count += 1
 	assert_eq(grass_eater_count, 1)
-	
+
 	var eater_iter:= GFQueryBuilder \
 		.new_in_world(world) \
 		.with(eats.pair("flecs/core/*")) \
@@ -74,7 +74,7 @@ func test_is_pair():
 	var likes = GFEntity.new_in_world(world).set_name("Likes")
 	var jill = GFEntity.new_in_world(world).set_name("Jill")
 	var likes_jill = likes.pair(jill)
-	
+
 	assert_true(likes_jill.is_pair())
 
 #endregion

--- a/unittests/test_simple_systems.gd
+++ b/unittests/test_simple_systems.gd
@@ -17,10 +17,10 @@ func after_all():
 	#world.new_pipeline(&"second")
 #
 	#var entity:= GFEntity.new_in_world(world) \
-		#.add_component(Bools) \
-		#.add_component(Ints) \
+		#.add(Bools) \
+		#.add(Ints) \
 		#.set_name("Test")
-	#var ints:Ints = entity.get_component(Ints)
+	#var ints:Ints = entity.get(Ints)
 #
 	#world.system_builder(&"first") \
 		#.with(Ints) \
@@ -35,19 +35,19 @@ func after_all():
 #
 	#ints.a = 0
 	#ints.b = 0
-	#assert_eq(entity.get_component(Ints).a, 0)
-	#assert_eq(entity.get_component(Ints).b, 0)
+	#assert_eq(entity.get(Ints).a, 0)
+	#assert_eq(entity.get(Ints).b, 0)
 	#world.run_pipeline(&"first", 0.0)
-	#assert_eq(entity.get_component(Ints).a, 25)
-	#assert_eq(entity.get_component(Ints).b, 0)
+	#assert_eq(entity.get(Ints).a, 25)
+	#assert_eq(entity.get(Ints).b, 0)
 #
 	#ints.a = 0
 	#ints.b = 0
-	#assert_eq(entity.get_component(Ints).a, 0)
-	#assert_eq(entity.get_component(Ints).b, 0)
+	#assert_eq(entity.get(Ints).a, 0)
+	#assert_eq(entity.get(Ints).b, 0)
 	#world.run_pipeline(&"second", 0.0)
-	#assert_eq(entity.get_component(Ints).a, 0)
-	#assert_eq(entity.get_component(Ints).b, 50)
+	#assert_eq(entity.get(Ints).a, 0)
+	#assert_eq(entity.get(Ints).b, 50)
 #
 	#entity.free()
 
@@ -60,13 +60,13 @@ func test_bools():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Bools) \
+		.add(Bools) \
 		.set_name("Test")
 
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(Bools).a, true)
-	assert_eq(entity.get_component(Bools).b, false)
+	assert_eq(entity.get(Bools).a, true)
+	assert_eq(entity.get(Bools).b, false)
 
 	entity.delete()
 
@@ -79,15 +79,15 @@ func test_ints():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Ints) \
+		.add(Ints) \
 		.set_name("Test")
-	entity.get_component(Ints).b = 1
+	entity.get(Ints).b = 1
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(Ints).a, 14)
+	assert_eq(entity.get(Ints).a, 14)
 
 	entity.delete()
 
@@ -100,15 +100,15 @@ func test_floats():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Floats) \
+		.add(Floats) \
 		.set_name("Test")
-	entity.get_component(Floats).b = 1.2
+	entity.get(Floats).b = 1.2
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_almost_eq(entity.get_component(Floats).a, 16.8, 0.05)
+	assert_almost_eq(entity.get(Floats).a, 16.8, 0.05)
 
 	entity.delete()
 
@@ -123,8 +123,8 @@ func test_strings():
 
 	var entity:= GFEntity.new_in_world(world) \
 		.set_name("Test") \
-		.add_component(Strings, "", "po")
-	var strings:Strings = entity.get_component(Strings)
+		.add(Strings, "", "po")
+	var strings:Strings = entity.get(Strings)
 	assert_eq(strings.a, "")
 	assert_eq(strings.b, "po")
 
@@ -146,16 +146,16 @@ func test_byte_arrays():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(ByteArrays) \
+		.add(ByteArrays) \
 		.set_name("Test")
-	entity.get_component(ByteArrays).a = PackedByteArray([1, 2, 3])
-	entity.get_component(ByteArrays).b = PackedByteArray([2, 4, 3])
+	entity.get(ByteArrays).a = PackedByteArray([1, 2, 3])
+	entity.get(ByteArrays).b = PackedByteArray([2, 4, 3])
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(ByteArrays).a, PackedByteArray([7, 14, 12]))
+	assert_eq(entity.get(ByteArrays).a, PackedByteArray([7, 14, 12]))
 
 	entity.delete()
 
@@ -168,23 +168,23 @@ func test_textures():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Textures) \
+		.add(Textures) \
 		.set_name("Test")
-	entity.get_component(Textures).a = null
-	entity.get_component(Textures).b = load("res://icon.svg")
+	entity.get(Textures).a = null
+	entity.get(Textures).b = load("res://icon.svg")
 
 	# Assert that setting Object to null works
-	assert_eq(entity.get_component(Textures).b, load("res://icon.svg"))
-	entity.get_component(Textures).b = null
-	assert_eq(entity.get_component(Textures).b, null)
-	entity.get_component(Textures).b = load("res://icon.svg")
+	assert_eq(entity.get(Textures).b, load("res://icon.svg"))
+	entity.get(Textures).b = null
+	assert_eq(entity.get(Textures).b, null)
+	entity.get(Textures).b = load("res://icon.svg")
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(Textures).a, load("res://icon.svg"))
-	assert_eq(entity.get_component(Textures).b, load("res://icon.svg"))
+	assert_eq(entity.get(Textures).a, load("res://icon.svg"))
+	assert_eq(entity.get(Textures).b, load("res://icon.svg"))
 
 	entity.delete()
 
@@ -193,13 +193,13 @@ func test_ref_counts():
 	assert_eq(rc.get_reference_count(), 1)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(RefCounts) \
+		.add(RefCounts) \
 		.set_name("Test")
 
-	entity.get_component(RefCounts).a = rc
+	entity.get(RefCounts).a = rc
 	assert_eq(rc.get_reference_count(), 2)
 
-	entity.get_component(RefCounts).a = null
+	entity.get(RefCounts).a = null
 	assert_eq(rc.get_reference_count(), 1)
 
 	entity.delete()
@@ -213,17 +213,17 @@ func test_arrays():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Arrays) \
+		.add(Arrays) \
 		.set_name("Test")
-	entity.get_component(Arrays).a = [23, 4, 6]
-	entity.get_component(Arrays).b = [1, 2, 1]
+	entity.get(Arrays).a = [23, 4, 6]
+	entity.get(Arrays).b = [1, 2, 1]
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(Arrays).a, [23, 4, 6])
-	assert_eq(entity.get_component(Arrays).b, [70, 14, 19])
+	assert_eq(entity.get(Arrays).a, [23, 4, 6])
+	assert_eq(entity.get(Arrays).b, [70, 14, 19])
 
 	entity.delete()
 
@@ -235,17 +235,17 @@ func test_dicts():
 			)
 
 	var entity:= GFEntity.new_in_world(world) \
-		.add_component(Dicts) \
+		.add(Dicts) \
 		.set_name("Test")
-	entity.get_component(Dicts).a = {"add_by": 5}
-	entity.get_component(Dicts).b = {"value": 2}
+	entity.get(Dicts).a = {"add_by": 5}
+	entity.get(Dicts).b = {"value": 2}
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_eq(entity.get_component(Dicts).a, {"add_by":5})
-	assert_eq(entity.get_component(Dicts).b, {"value":17})
+	assert_eq(entity.get(Dicts).a, {"add_by":5})
+	assert_eq(entity.get(Dicts).b, {"value":17})
 
 	entity.delete()
 

--- a/unittests/test_systems.gd
+++ b/unittests/test_systems.gd
@@ -22,10 +22,10 @@ func test_stuff():
 			)
 
 	var e:= GFEntity.new_in_world(world) \
-		.add_component(Bools) \
+		.add(Bools) \
 		.set_name("Test")
 	world.register_script(Bools)
-	var bools = e.get_component(Bools)
+	var bools = e.get(Bools)
 	bools.a = true
 	bools.b = false
 


### PR DESCRIPTION
Shortens methods like `get_component` to just `get`. Also adds `GFComponent.setm_no_notify()` method.