### PR TITLE
[Feature] Implement getting and setting primitives data

### DIFF
--- a/cpp/src/component.cpp
+++ b/cpp/src/component.cpp
@@ -231,12 +231,37 @@ void GFComponent::build_data_from_members(
 	ecs_entity_t component_id,
 	const GFWorld* world
 ) {
-	const EcsStruct* struct_data = GFComponent::get_struct_ptr(world, component_id);
-	if (struct_data == nullptr) {
+	if (members.size() == 0) {
 		ERR(/**/,
-			"Could not build data from Array\n",
-			"	Entity ", world->id_to_text(component_id), " is not a struct."
+			"Could not set component's data\n",
+			"	No values were provided."
 		);
+	}
+
+	const EcsStruct* struct_data = GFComponent::get_struct_ptr(
+		world,
+		component_id
+	);
+	if (struct_data == nullptr) {
+		// Component is not a struct--maybe a primitive
+		if (!ecs_has_id(world->raw(), component_id, ecs_id(EcsPrimitive))) {
+			ERR(/**/,
+				"Could not set component's data\n",
+				"	Component ", world->id_to_text(component_id), " is not a struct or primitive."
+			);
+		}
+		if (members.size() > 1) {
+			ERR(/**/,
+				"Could not set component's data\n",
+				"	Component ", world->id_to_text(component_id),
+				" is a primitive, but more than value was provided."
+			);
+		}
+
+		// Component is a primitive, and exactly one value was provided
+		// Set primitive from value
+		Utils::set_type_from_variant(members[0], component_id, world, output);
+		return;
 	}
 
 	for (int i=0; i != members.size() && i != ecs_vec_size(&struct_data->members); i++) {

--- a/cpp/src/component.cpp
+++ b/cpp/src/component.cpp
@@ -266,8 +266,8 @@ void GFComponent::_bind_methods() {
 	GDVIRTUAL_BIND(_build, "b");
 	godot::ClassDB::bind_method(D_METHOD("_register_internal"), &GFComponent::_register_internal);
 
-	godot::ClassDB::bind_static_method(get_class_static(), D_METHOD("from", "component", "world"), &GFComponent::from, nullptr);
-	godot::ClassDB::bind_static_method(get_class_static(), D_METHOD("from_id", "id", "world"), &GFComponent::from_id, nullptr);
+	godot::ClassDB::bind_static_method(get_class_static(), D_METHOD("from", "component", "entity", "world"), &GFComponent::from, nullptr);
+	godot::ClassDB::bind_static_method(get_class_static(), D_METHOD("from_id", "component_id", "entity_id","world"), &GFComponent::from_id, nullptr);
 
 	godot::ClassDB::bind_method(D_METHOD("getm", "member"), &GFComponent::getm);
 	godot::ClassDB::bind_method(D_METHOD("setm", "member", "value"), &GFComponent::setm);

--- a/cpp/src/doc_classes/GFComponent.xml
+++ b/cpp/src/doc_classes/GFComponent.xml
@@ -93,17 +93,17 @@
 		<method name="from" qualifiers="static">
 			<return type="GFComponent" />
 			<param index="0" name="component" type="Variant" />
-			<param index="1" name="world" type="Variant" />
-			<param index="2" name="_unnamed_arg2" type="GFWorld" default="null" />
+			<param index="1" name="entity" type="Variant" />
+			<param index="2" name="world" type="GFWorld" default="null" />
 			<description>
 				Overrides [method GFEntity.from].
 			</description>
 		</method>
 		<method name="from_id" qualifiers="static">
 			<return type="GFComponent" />
-			<param index="0" name="id" type="int" />
-			<param index="1" name="world" type="int" />
-			<param index="2" name="_unnamed_arg2" type="GFWorld" default="null" />
+			<param index="0" name="component_id" type="int" />
+			<param index="1" name="entity_id" type="int" />
+			<param index="2" name="world" type="GFWorld" default="null" />
 			<description>
 				Overrides [method GFEntity.from_id].
 			</description>

--- a/cpp/src/doc_classes/GFEntity.xml
+++ b/cpp/src/doc_classes/GFEntity.xml
@@ -18,7 +18,7 @@
 				[codeblock]
 				var entity:= GFEntity.new()
 				entity.add(GFPosition2D, Vector2(10, 10))
-				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.get(GFPosition2D) == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>
@@ -109,7 +109,7 @@
 				[codeblock]
 				var entity:= GFEntity.new()
 				entity.addv(GFPosition2D, [Vector2(10, 10)])
-				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.get(GFPosition2D) == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>
@@ -179,16 +179,17 @@
 			</description>
 		</method>
 		<method name="get" qualifiers="const">
-			<return type="GFComponent" />
+			<return type="Variant" />
 			<param index="0" name="entity" type="Variant" />
 			<param index="1" name="second" type="Variant" default="null" />
 			<description>
-				Returns a reference to this entity's component's data of type [param component].
+				Returns either a reference to this entity's component's data or returns the data directly.
+				If the component is a primitive, or only has a single member, then the primitive, or the single member, will be returned as a Variant. In all other cases, a [GFComponent] is returned and [method GFComponent.getm] can be used to retrieve the member you need.
 				Returns [code]null[/code] if the entity does not have the [param component] attached or if [param component] is not a component. The component is identified by an ID coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
 				[codeblock]
 				var entity:= GFEntity.new()
-				entity.add("glecs/meta/Array")
-				entity.get("glecs/meta/Array") != null # true
+				entity.add("glecs/meta/int")
+				entity.get("glecs/meta/int") == 0 # true
 				[/codeblock]
 			</description>
 		</method>
@@ -453,14 +454,14 @@
 				var entity:= GFEntity.new()
 				entity.add(GFPosition2D)
 				entity.set(GFPosition2D, Vector2(10, 10))
-				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.get(GFPosition2D) == Vector2(10, 10) # true
 				[/codeblock]
 				If the component is not added yet, then this method will add
 				it automaticly.
 				[codeblock]
 				var entity:= GFEntity.new()
 				entity.set(GFPosition2D, Vector2(10, 10))
-				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.get(GFPosition2D) == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>
@@ -544,14 +545,14 @@
 				var entity:= GFEntity.new()
 				entity.add(GFPosition2D)
 				entity.setv(GFPosition2D, [Vector2(10, 10)])
-				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.get(GFPosition2D) == Vector2(10, 10) # true
 				[/codeblock]
 				If the component is not added yet, then this method will add
 				it automaticly.
 				[codeblock]
 				var entity:= GFEntity.new()
 				entity.setv(GFPosition2D, [Vector2(10, 10)])
-				entity.get(GFPosition2D).get_vec() == Vector2(10, 10) # true
+				entity.get(GFPosition2D) == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>

--- a/cpp/src/entity.cpp
+++ b/cpp/src/entity.cpp
@@ -375,11 +375,11 @@ Ref<GFEntity> GFEntity::emit(
 	return Ref(this);
 }
 
-Ref<GFComponent> GFEntity::get_component(const Variant entity, const Variant second) const {
+Variant GFEntity::get_component(const Variant entity, const Variant second) const {
 	GFWorld* w = get_world();
 
-	ecs_entity_t id = w->coerce_id(entity);
-	CHECK_ENTITY_ALIVE(id, w, nullptr,
+	ecs_entity_t comp_id = w->coerce_id(entity);
+	CHECK_ENTITY_ALIVE(comp_id, w, nullptr,
 		"Failed to get component\n"
 	);
 
@@ -389,25 +389,51 @@ Ref<GFComponent> GFEntity::get_component(const Variant entity, const Variant sec
 			"Failed to get component\n"
 		);
 
-		id = ecs_pair(id, second_id);
+		comp_id = ecs_pair(comp_id, second_id);
 	}
 
-	if (!ecs_has_id(get_world()->raw(), get_id(), id)) {
+	if (!ecs_has_id(get_world()->raw(), get_id(), comp_id)) {
 		ERR(nullptr,
 			"Failed to get component\n	Could not find attached component ID: ",
-			w->id_to_text(id),
+			w->id_to_text(comp_id),
 			" on entity: ",
 			this
 		);
 	}
 
-	Ref<GFComponent> c = GFComponent::from_id(
-		id,
+	ecs_entity_t comp_id_main = w->get_main_id(comp_id);
+
+	const EcsStruct* struct_c = ecs_get(w->raw(), comp_id_main, EcsStruct);
+	if (struct_c != nullptr) {
+		// Component is a struct
+		if (ecs_vec_count(&struct_c->members) == 1) {
+			// Struct only has one member--return just the member instead of
+			// the whole component reference
+			ecs_member_t* member = ecs_vec_get_t(&struct_c->members, ecs_member_t, 0);
+			return w->_variant_from_member_ptr(
+				w->_comp_get_member_ptr_mut_at(get_id(), comp_id, 0),
+				member->type
+			);
+		}
+	} else {
+		// Component is not a struct--maybe primitive
+		const EcsPrimitive* primitive_c = ecs_get(w->raw(), comp_id_main, EcsPrimitive);
+		if (primitive_c != nullptr) {
+			// Component is a primitive--return just the primitive instead
+			// of the whole component reference
+			return w->_variant_from_member_ptr_primitive(
+				w->_comp_get_member_ptr_mut_at(get_id(), comp_id, 0),
+				primitive_c->kind
+			);
+		}
+	}
+
+	Ref<GFComponent> c_reference = GFComponent::from_id(
+		comp_id,
 		get_id(),
 		get_world()
 	);
-
-	return c;
+	return c_reference;
 }
 
 bool GFEntity::has_entity(const Variant entity, const Variant second) const {

--- a/cpp/src/entity.h
+++ b/cpp/src/entity.h
@@ -145,7 +145,7 @@ namespace godot {
 
 		Ref<GFEntity> get_child(const String) const;
 		TypedArray<GFEntity> get_children() const;
-		Ref<GFComponent> get_component(const Variant, const Variant) const;
+		Variant get_component(const Variant, const Variant) const;
 		static const RegEx* get_entity_id_regex();
 		ecs_entity_t get_id() const;
 		String get_name() const;
@@ -187,7 +187,6 @@ namespace godot {
 				get_class(),
 				script->get_instance_base_type()
 			)) {
-				// UtilityFunctions::prints("SCRIPT INCAPAT", get_class(), script->get_instance_base_type(), script->get_path());
 				return;
 			}
 			set_script(script);

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -107,6 +107,8 @@ bool Utils::can_convert_type_to_primitive(Variant::Type type, ecs_primitive_kind
 			switch (primi) {
 				case EcsU8: case EcsU16: case EcsU32: case EcsU64:
 				case EcsI8: case EcsI16: case EcsI32: case EcsI64:
+				case EcsF32: case EcsF64:
+				case EcsId: case EcsEntity: case EcsChar: case EcsByte:
 					return true;
 				default:
 					return false;
@@ -114,6 +116,8 @@ bool Utils::can_convert_type_to_primitive(Variant::Type type, ecs_primitive_kind
 		}
         case Variant::FLOAT: {
 			switch (primi) {
+				case EcsU8: case EcsU16: case EcsU32: case EcsU64:
+				case EcsI8: case EcsI16: case EcsI32: case EcsI64:
 				case EcsF32: case EcsF64:
 					return true;
 				default:
@@ -178,13 +182,13 @@ void Utils::set_primitive_from_variant(
 	case EcsI64: *static_cast<int64_t*>(out) = value; break;
 	case EcsF32: *static_cast<real_t*>(out) = value; break;
 	case EcsF64: *static_cast<double*>(out) = value; break;
-	case EcsId: *static_cast<ecs_entity_t*>(out) = value; break;
-	case EcsChar: ERR(/**/, "Can not convert to char primitive from Variant type ", Variant::get_type_name(value.get_type()));
-	case EcsByte: ERR(/**/, "Can not convert to byte primitive from Variant type ", Variant::get_type_name(value.get_type()));
+	case EcsId: *static_cast<ecs_id_t*>(out) = value; break;
+	case EcsChar: *static_cast<uint8_t*>(out) = value; break;
+	case EcsByte: *static_cast<uint8_t*>(out) = value; break;
 	case EcsUPtr: ERR(/**/, "Can not convert to UPointer primitive from Variant type ", Variant::get_type_name(value.get_type()));
 	case EcsIPtr: ERR(/**/, "Can not convert to IPointer primitive from Variant type ", Variant::get_type_name(value.get_type()));
 	case EcsString: ERR(/**/, "Can not convert to string primitive from Variant type ", Variant::get_type_name(value.get_type()));
-	case EcsEntity: ERR(/**/, "Can not convert to entity primitive from Variant type ", Variant::get_type_name(value.get_type()));
+	case EcsEntity: *static_cast<ecs_entity_t*>(out) = value; break;
 	}
 }
 

--- a/cpp/src/world.cpp
+++ b/cpp/src/world.cpp
@@ -1359,7 +1359,14 @@ void GFWorld::init_gd_type_ptr(
 }
 
 bool GFWorld::id_has_child(ecs_entity_t parent, const char* child_name) const {
-	return ecs_lookup_child(raw(),parent, child_name) != 0;
+	return ecs_lookup_path_w_sep(
+		raw(),
+		parent,
+		child_name,
+		"/",
+		"/root/",
+		false
+	) != 0;
 }
 
 bool GFWorld::id_set_parent(ecs_entity_t id, ecs_entity_t parent) const {
@@ -1370,17 +1377,16 @@ bool GFWorld::id_set_parent(ecs_entity_t id, ecs_entity_t parent) const {
 		"Failed to set parent\n	Parent is not alive\n"
 	);
 
-	// TODO: Handle name conflicts rather than throw error
 	String new_name = String();
-	if (ecs_has_id(raw(), id, EcsName) && id_has_child(parent, ecs_get_name(raw(), id))) {
-		// Entity needs new name in parent
+	if (id_has_child(parent, ecs_get_name(raw(), id))) {
+		// Entity needs a unique name in new parent
 		new_name = entity_unique_name(parent, ecs_get_name(raw(), id));
-		ecs_remove_id(raw(), id, EcsName);
+		ecs_remove_pair(raw(), id, ecs_id(EcsIdentifier), EcsName);
 	}
 
 	ecs_add_id(raw(), id, ecs_childof(parent));
 
-	if (new_name != String()) {
+	if (!new_name.is_empty()) {
 		// Set new name
 		CharString char_new_name = new_name.utf8();
 		ecs_set_name(raw(), id, char_new_name);
@@ -1422,10 +1428,15 @@ Variant GFWorld::_variant_from_member_ptr(
 ) const {
 	Variant::Type vari_type = id_as_variant_type(member_type);
 	if (vari_type == Variant::NIL) {
+		// Member is not a godot type--maybe primitive?
 		const EcsPrimitive* primi_c = ecs_get(raw(), member_type, EcsPrimitive);
 		if (primi_c != nullptr) {
+			// Member is a primitive, convert primitive to Godot type
 			return _variant_from_member_ptr_primitive(ptr, primi_c->kind);
 		}
+
+		// Member was not a primitive, and can't be converted to a Godot type
+		return nullptr;
 	}
 
 	switch (vari_type) {

--- a/cpp/src/world.cpp
+++ b/cpp/src/world.cpp
@@ -180,6 +180,12 @@ void GFWorld::setup_glecs() {
 	define_gd_literal("float", ecs_primitive_kind_t::EcsF64, &glecs_meta_float);
 	define_gd_component<String>("String", &glecs_meta_string);
 
+	EcsType struct_type = {
+		kind: ecs_type_kind_t::EcsStructType,
+		existing: true,
+		partial: false,
+	};
+
 	{ // Add glecs/meta/Vector2 type
 		ecs_struct_desc_t desc = {
 			.entity = glecs_meta_vector2,
@@ -196,6 +202,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_vector2, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Vector2i type
@@ -214,6 +221,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_vector2i, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Rect type
@@ -232,6 +240,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_rect2, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Rect2i type
@@ -250,6 +259,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_rect2i, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Vector3 type
@@ -269,6 +279,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_vector3, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Vector3i type
@@ -288,6 +299,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_vector3i, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Transform2D type
@@ -307,6 +319,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_transform2d, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Vector4 type
@@ -327,6 +340,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_vector4, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Vector4i type
@@ -347,6 +361,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_vector4i, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Plane type
@@ -368,6 +383,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_plane, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Quaternion type
@@ -388,6 +404,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_quaternion, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/AABB type
@@ -406,6 +423,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_aabb, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Basis type
@@ -425,6 +443,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_basis, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Transform3D type
@@ -443,6 +462,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_transform3d, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Projection type
@@ -463,6 +483,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_projection, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	{ // Add glecs/meta/Color type
@@ -483,6 +504,7 @@ void GFWorld::setup_glecs() {
 			"/",
 			"/root/"
 		);
+		ecs_set_id(raw(), glecs_meta_color, ecs_id(EcsType), sizeof(EcsType), &struct_type);
 	}
 
 	define_gd_component<StringName>("StringName", &glecs_meta_string_name);

--- a/cpp/src/world.h
+++ b/cpp/src/world.h
@@ -241,6 +241,11 @@ namespace godot {
 			const char* name,
 			const ecs_entity_t* static_id
 		) {
+			EcsType type = {
+				kind: ecs_type_kind_t::EcsOpaqueType,
+				existing: true,
+				partial: false,
+			};
 			ecs_component_desc_t desc = {
 				.entity = *static_id,
 				.type = {
@@ -254,6 +259,7 @@ namespace godot {
 				.copy = GFWorld::gd_type_copy<T>,
 				.move = GFWorld::gd_type_move<T>
 			}; ecs_set_hooks_id(_raw, *static_id, &hooks);
+			ecs_set_id(raw(), *static_id, ecs_id(EcsType), sizeof(EcsType), &type);
 			ecs_add_path_w_sep(
 				_raw,
 				*static_id,

--- a/examples/asteroids/asteroids.gd
+++ b/examples/asteroids/asteroids.gd
@@ -32,11 +32,11 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	GFWorld.get_default_world().progress(0)
 	
-	c.get(GFCanvasItem).set_parent_canvas_item(e.get(GFCanvasItem).get_rid())
-
-	var rot_c:GFRotation2D = e.get(GFRotation2D)
 	if Input.get_axis("ui_left", "ui_right"):
-		rot_c.set_angle(rot_c.get_angle() + (delta * Input.get_axis("ui_left", "ui_right")))
+		e.set(GFRotation2D,
+			e.get(GFRotation2D)
+			+ (delta * Input.get_axis("ui_left", "ui_right")),
+			)
 
 	var v_axis:= Input.get_axis("ui_up", "ui_down")
 	if v_axis:
@@ -65,10 +65,8 @@ func _process(delta: float) -> void:
 		e.set(GFColorRect.color, Color(randf(), randf(), randf()))
 		c.set(GFColorRect.color, Color(randf(), randf(), randf()))
 	
-	var skew_c:= e.get(GFSkew2D)
-	prints(Input.is_key_pressed(KEY_6), int(Input.is_key_pressed(KEY_6)))
-	skew_c.set_skew(
-		skew_c.get_skew()
+	e.set(GFSkew2D,
+		e.get(GFSkew2D)
 		+ (int(Input.is_key_pressed(KEY_6)) - int(Input.is_key_pressed(KEY_5)))
 		* delta
 		)

--- a/examples/asteroids/asteroids.tscn
+++ b/examples/asteroids/asteroids.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://dglcrfdcbfvvf"]
+[gd_scene load_steps=4 format=3 uid="uid://dglcrfdcbfvvf"]
 
 [ext_resource type="Script" uid="uid://i3yerw3l8inx" path="res://addons/glecs/examples/asteroids/asteroids.gd" id="1_i0ls5"]
+[ext_resource type="Texture2D" uid="uid://bw1r1ue5j75sw" path="res://icon.png" id="2_yg5ts"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_xs1py"]
 blend_mode = 1
@@ -31,3 +32,8 @@ offset_top = -15.0
 offset_right = 159.0
 offset_bottom = 117.0
 color = Color(0.6463204, 0.32611704, 0.3726708, 1)
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("2_yg5ts")
+centered = false
+region_enabled = true

--- a/gd/rendering/_systems.gd
+++ b/gd/rendering/_systems.gd
@@ -380,10 +380,10 @@ func _register(w:GFWorld):
 	#endregion
 
 static func queue_redraw(entity:GFEntity) -> void:
-	var item:= entity.get(GFCanvasItem)
+	var item:RID = entity.get(GFCanvasItem)
 	if not item:
 		return
 
-	RenderingServer.canvas_item_clear(item.get_rid())
+	RenderingServer.canvas_item_clear(item)
 	GFEntity.from(GFOnDraw, entity.get_world()) \
 		.emit(entity)

--- a/unittests/test_components.gd
+++ b/unittests/test_components.gd
@@ -123,6 +123,23 @@ func test_setm_no_notify():
 	assert_eq(data.i, 1)
 
 
+func test_primitive():
+	var Int:= world.lookup("/root/glecs/meta/int")
+	var array:= world.lookup("/root/glecs/meta/Array")
+	
+	var e:= GFEntity.new()
+	e.add(Int)
+	e.set(Int, 25)
+	assert_eq(e.get(Int), 25)
+	
+	e.add(array)
+	e.set(array, [2, 3])
+	var arr = e.get(array)
+	assert_eq(arr.size(), 2)
+	assert_eq(arr[0], 2)
+	assert_eq(arr[1], 3)
+
+
 class Targets extends GFRegisterableEntity: pass
 
 

--- a/unittests/test_components.gd
+++ b/unittests/test_components.gd
@@ -23,13 +23,13 @@ func test_add_entity():
 
 func test_world_deletion():
 	var w:= GFWorld.new()
-	
+
 	var e:= GFEntity.new_in_world(w) \
 		.add(Foo) \
 		.set_name("Test")
 	var foo:= e.get(Foo)
 	assert_eq(e.get_world(), w)
-	
+
 	var e2:= GFEntity.new_in_world(w) \
 		.add(Foo) \
 		.set_name("Test")
@@ -106,7 +106,7 @@ func test_components_in_relationships():
 func test_setm_no_notify():
 	var e:= GFEntity.new() \
 		.add(Foo)
-	
+
 	var data:= {i = 0}
 	GFObserverBuilder.new() \
 		.set_events("/root/flecs/core/OnSet") \
@@ -117,11 +117,11 @@ func test_setm_no_notify():
 	foo.setm_no_notify("value", Vector2(23, 17))
 	assert_eq(foo.getm("value"), Vector2(23, 17))
 	assert_eq(data.i, 0)
-	
+
 	foo.setm("value", Vector2.ONE)
 	assert_eq(foo.getm("value"), Vector2.ONE)
 	assert_eq(data.i, 1)
-	
+
 
 class Targets extends GFRegisterableEntity: pass
 
@@ -129,6 +129,7 @@ class Targets extends GFRegisterableEntity: pass
 class Foo extends GFComponent:
 	func _build(b: GFComponentBuilder) -> void:
 		b.add_member("value", TYPE_VECTOR2)
+		b.add_member("_", TYPE_VECTOR2)
 
 	func get_value() -> Vector2:
 		return getm(&"value")

--- a/unittests/test_ecs_world.gd
+++ b/unittests/test_ecs_world.gd
@@ -95,10 +95,10 @@ func test_entity_created_in_local_thread_world():
 
 func test_set_default_world_doc_example():
 	var custom_default_world = GFWorld.new()
-	
+
 	var old_default_world = GFWorld.get_default_world()
 	GFWorld.set_default_world(custom_default_world)
-	
+
 	# The following line is similar to calling this:
 	# var entity = GFEntity.new_in_world(custom_default_world)
 	var entity = GFEntity.new()
@@ -106,10 +106,11 @@ func test_set_default_world_doc_example():
 	# It is a good practice to restore the default
 	# world to whatever it was before you set it.
 	GFWorld.set_default_world(old_default_world)
-	
+
 	assert_eq(GFWorld.get_default_world(), world)
 	assert_eq(entity.get_world(), custom_default_world)
 
 class Foo extends GFComponent:
 	func _build(b: GFComponentBuilder) -> void:
 		b.add_member("vec", TYPE_FLOAT)
+		b.add_member("_", TYPE_FLOAT)

--- a/unittests/test_entities.gd
+++ b/unittests/test_entities.gd
@@ -16,15 +16,16 @@ func after_each():
 #region Tests
 
 func test_component_get_and_set():
-	var e:GFEntity = GFEntity.new() \
-		.add(Foo) \
-		.set_name("Test")
+	var e:GFEntity = GFEntity.new()
+	e.add(Foo)
+	e.set_name("Test")
 
-	var foo:Foo = e.get(Foo)
-	assert_almost_eq(foo.value, 0.0, 0.01)
+	var x = e.get(Foo)
 
-	foo.value = 2.3
-	assert_almost_eq(foo.value, 2.3, 0.01)
+	assert_almost_eq(e.get(Foo), 0.0, 0.01)
+
+	e.set(Foo, 2.3)
+	assert_almost_eq(e.get(Foo), 2.3, 0.01)
 
 	e.delete()
 
@@ -32,8 +33,6 @@ func test_component_string_get_and_set():
 	var e:= GFEntity.new() \
 		.add(Stringy) \
 		.set_name("Test")
-
-	prints(e.get_property_list())
 
 	var foo:Stringy = e.get(Stringy)
 	foo.a = "po"
@@ -49,7 +48,7 @@ func test_new_entity_with_unregistered_component():
 	var e:GFEntity = GFEntity.new() \
 		.add(Unregistered) \
 		.set_name("Test")
-	assert_eq(e.get(Unregistered).value, 0)
+	assert_eq(e.get(Unregistered), 0)
 
 func test_creating_entity_by_new():
 	# Test that an entity is invalidated by being deleted
@@ -199,18 +198,18 @@ func test_remove():
 		.set_name("RemovingFrom") \
 		.add(Foo, 2.24) \
 		.add_pair(Foo, Stringy, 234.1)
-	
+
 	assert_true(e.has(Foo), "Expected RemovingFrom to have (Foo, Stringy)")
-	assert_almost_eq(e.get(Foo).getm("value"), 2.24, 0.01)
+	assert_almost_eq(e.get(Foo), 2.24, 0.01)
 	assert_true(e.has(Foo, Stringy), "Expected RemovingFrom to have (Foo, Stringy)")
-	assert_almost_eq(e.get(Foo, Stringy).getm("value"), 234.1, 0.01)
-	
+	assert_almost_eq(e.get(Foo, Stringy), 234.1, 0.01)
+
 	e.remove(Foo)
 	e.remove(Foo, Stringy)
-	
+
 	assert_false(e.has(Foo))
 	assert_false(e.has(Foo, Stringy))
-	
+
 func test_add_sibling():
 	var par:= GFEntity.new()
 	var bill:= GFEntity.new() \
@@ -219,7 +218,7 @@ func test_add_sibling():
 		.add_sibling(GFEntity.new()
 			.set_name("Bob")
 		)
-	
+
 	assert_true(par.has_child("Bill"), "Expected parent to have have child named Bill")
 	assert_true(par.has_child("Bob"), "Expected parent to have have child named Bob")
 
@@ -229,18 +228,18 @@ func test_inheritance():
 		.add(GFPosition2D) \
 		.build() \
 		.set(GFPosition2D, Vector2(2, 3))
-	
+
 	assert_true(
 		ship_pfb.has(GFPosition2D),
 		"Expected `ship_pfb` to have position"
 	)
 	assert_almost_eq(
-		ship_pfb.get(GFPosition2D).get_vec(),
+		ship_pfb.get(GFPosition2D),
 		Vector2(2, 3),
 		Vector2(0.01, 0.01),
 		"Expected position in `ship_pfb` to have been set",
 	)
-	
+
 	var e:= GFEntity.new()
 	assert_false(
 		e.is_inheriting(ship_pfb),
@@ -250,7 +249,7 @@ func test_inheritance():
 		e.has(GFPosition2D),
 		"Expected `e` to NOT have position yet",
 	)
-	
+
 	e.inherit(ship_pfb)
 
 	assert_true(
@@ -261,18 +260,18 @@ func test_inheritance():
 		e.has(GFPosition2D),
 		"Expected `e` to have inherited position from `ship_pfb`",
 	)
-	
+
 	e.set(GFPosition2D, Vector2(5, 4))
-	
+
 	assert_almost_eq(
-		e.get(GFPosition2D).get_vec(),
+		e.get(GFPosition2D),
 		Vector2(5, 4),
 		Vector2(0.01, 0.01),
 		"Expected position in `e` to have been set",
 	)
 	assert_almost_ne(
-		e.get(GFPosition2D).get_vec(),
-		ship_pfb.get(GFPosition2D).get_vec(),
+		e.get(GFPosition2D),
+		ship_pfb.get(GFPosition2D),
 		Vector2(0.01, 0.01),
 		"Expected position in `e` to differ from position in `ship_pfb`",
 	)
@@ -294,7 +293,7 @@ func test_get_target_for():
 		.set_name("Enterprise") \
 		.add_pair(GFPosition2D, GFScale2D) \
 		.add_pair(GFPosition2D, GFRotation2D)
-	
+
 	var targets:= []
 	var i:= 0
 	while true:
@@ -304,7 +303,7 @@ func test_get_target_for():
 		else:
 			break
 		i += 1
-		
+
 	assert_true(
 		world.coerce_id(GFRotation2D) in targets,
 		"Expected Enterprise to have a position pair with a rotation target",
@@ -318,13 +317,13 @@ func test_get_target_for():
 		2,
 		"Expected Enterprise to have two position pairs",
 	)
-		
+
 func test_is_owner_of():
 	world.start_rest_api()
-	
+
 	var isa:= world.coerce_id("flecs/core/IsA")
 	var inherit:= world.pair("flecs/core/OnInstantiate", "flecs/core/Inherit")
-	
+
 	var pos:= GFComponentBuilder.new() \
 		.set_name("Pos") \
 		.add(inherit) \
@@ -338,13 +337,13 @@ func test_is_owner_of():
 		.set_name("Scl") \
 		.add_member("_", TYPE_INT) \
 		.build()
-		
+
 	var spaceship:= GFEntity.new() \
 		.set_name("Spaceship") \
 		.add("flecs/core/Prefab") \
 		.add(pos) \
 		.add(rot)
-		
+
 	var enterprise:= GFEntity.new() \
 		.set_name("Enterprise") \
 		.inherit(spaceship) \
@@ -353,20 +352,20 @@ func test_is_owner_of():
 		.set_name("Voyager") \
 		.inherit(spaceship) \
 		.add(pos)
-	
+
 	assert_false(enterprise.is_owner_of(pos), "Expected position to be owned by spaceship, not enterprise")
 	assert_true(enterprise.is_owner_of(rot), "Expected rotation to be owned by enterprise")
 	assert_true(enterprise.is_owner_of(scl), "Expected rotation to be owned by enterprise")
-	
+
 	assert_true(voyager.is_owner_of(pos), "Expected position to be owned by voyager")
 	assert_true(voyager.is_owner_of(rot), "Expected rotation to be owned by voyager")
 
 	enterprise.remove(isa, spaceship)
 	voyager.remove(isa, spaceship)
-	
+
 	assert_false(enterprise.has(isa, spaceship), "Expected isa pair to have been removed from enterprise")
 	assert_false(voyager.has(isa, spaceship), "Expected isa pair to have been removed from voyager")
-	
+
 	assert_false(enterprise.has(pos), "Expected pos to have been removed from enterprise")
 	assert_true(enterprise.has(rot), "Expected enterprise to have rot")
 	assert_true(voyager.has(pos), "Expected voyager to have pos")
@@ -374,13 +373,13 @@ func test_is_owner_of():
 
 func test_clear():
 	var tag:= GFEntity.new().set_name("tag")
-	
+
 	var e:= GFEntity.new() \
 		.set_name("Entity") \
 		.add(tag)
-	
+
 	assert_true(e.has(tag))
-	
+
 	e.clear()
 
 	assert_false(e.has(tag))
@@ -394,16 +393,18 @@ func test_set_name():
 	assert_eq(e1.get_name(), "E1")
 	assert_eq(e2.get_name(), "E2")
 	assert_eq(e3.get_name(), "E3")
-	
+
 	# Entities should make get a unique name
 	# when moved to a parent.
 	var parent:= GFEntity.new()
 	var child_1:= GFEntity.new() \
 		.set_name("Child") \
 		.set_parent(parent)
-	var child_2:= GFEntity.new() \
-		.set_name("Child") \
-		.set_parent(parent)
+
+	var child_2:= GFEntity.new()
+	child_2.set_name("Child")
+	child_2.set_parent(parent)
+
 	assert_eq(child_1.get_name(), "Child")
 	assert_eq(child_2.get_name(), "Child1")
 
@@ -415,9 +416,6 @@ class Foo extends GFComponent:
 	func _build(b_: GFComponentBuilder) -> void: b_ \
 		.set_name("Foo") \
 		.add_member("value", TYPE_FLOAT)
-	var value:float:
-		get: return getm(&"value")
-		set(v): setm(&"value", v)
 
 class Stringy extends GFComponent:
 	func _build(b_: GFComponentBuilder) -> void: b_ \

--- a/unittests/test_errors.gd
+++ b/unittests/test_errors.gd
@@ -40,6 +40,7 @@ func test_new_entity_with_unregistered_component():
 class Foo extends GFComponent:
 	func _build(b_: GFComponentBuilder) -> void:
 		b_.add_member("vec", TYPE_FLOAT)
+		b_.add_member("_", TYPE_FLOAT)
 
 class Unregistered extends GFComponent:
 	func _build(b_: GFComponentBuilder) -> void:

--- a/unittests/test_events.gd
+++ b/unittests/test_events.gd
@@ -87,7 +87,7 @@ func test_on_add_event_with_objects():
 		.add(Textures) \
 		.set_name("WithInts")
 	assert_eq(data.i, 1)
-	assert_eq(e.get(Textures).a, null)
+	assert_eq(e.get(Textures), null)
 
 	e.delete()
 
@@ -98,7 +98,7 @@ func test_on_add_event_with_objects():
 		.set_name("WithTextures")
 	e2.add(Textures, load("res://icon.png"))
 	assert_eq(data.i, 1)
-	assert_eq(e2.get(Textures).a, load("res://icon.png"))
+	assert_eq(e2.get(Textures), load("res://icon.png"))
 
 	e2.delete()
 
@@ -142,8 +142,5 @@ class Ints extends GFComponent:
 class Textures extends GFComponent:
 	func _build(b:GFComponentBuilder) -> void:
 		b.add_member("a", TYPE_OBJECT)
-	var a:Texture2D:
-		get: return getm(&"a")
-		set(v): setm(&"a", v)
 
 #endregion

--- a/unittests/test_queries.gd
+++ b/unittests/test_queries.gd
@@ -203,7 +203,6 @@ func test_query_source():
 	p1.add(Bools)
 	var c1:= GFEntity.new()
 	p1.add_child(c1)
-	prints(2)
 	var p2:= GFEntity.new()
 	p2.set_name("WithoutBools")
 	p2.add_child(GFEntity.new())

--- a/unittests/test_relations.gd
+++ b/unittests/test_relations.gd
@@ -23,21 +23,21 @@ func test_add_and_set_pairs() -> void:
 
 	e.add_pair("Eats", GFRotation2D, 3.0)
 	assert_almost_eq(
-		e.get(eats.pair(GFRotation2D)).get_angle(),
+		e.get(eats.pair(GFRotation2D)),
 		3.0,
 		0.01,
 	)
 
-	e.set_pair(eats, GFRotation2D, 1.5)
+	e.set_pair(eats, GFRotation2D, 3000)
 	e.add_pair(GFRotation2D, eats, 1.1)
 
 	assert_almost_eq(
-		e.get(eats, GFRotation2D).get_angle(),
-		1.5,
+		e.get(eats, GFRotation2D),
+		3000.0,
 		0.01,
 	)
 	assert_almost_eq(
-		e.get(GFRotation2D, eats).get_angle(),
+		e.get(GFRotation2D, eats),
 		1.1,
 		0.01,
 	)

--- a/unittests/test_simple_systems.gd
+++ b/unittests/test_simple_systems.gd
@@ -175,20 +175,20 @@ func test_textures():
 		.add(Textures) \
 		.set_name("Test")
 	entity.get(Textures).a = null
-	entity.get(Textures).b = load("res://icon.svg")
+	entity.get(Textures).b = load("res://icon.png")
 
 	# Assert that setting Object to null works
-	assert_eq(entity.get(Textures).b, load("res://icon.svg"))
+	assert_eq(entity.get(Textures).b, load("res://icon.png"))
 	entity.get(Textures).b = null
 	assert_eq(entity.get(Textures).b, null)
-	entity.get(Textures).b = load("res://icon.svg")
+	entity.get(Textures).b = load("res://icon.png")
 
 	world.progress(0.0)
 	world.progress(0.0)
 	world.progress(0.0)
 
-	assert_eq(entity.get(Textures).a, load("res://icon.svg"))
-	assert_eq(entity.get(Textures).b, load("res://icon.svg"))
+	assert_eq(entity.get(Textures).a, load("res://icon.png"))
+	assert_eq(entity.get(Textures).b, load("res://icon.png"))
 
 	entity.delete()
 

--- a/unittests/test_systems.gd
+++ b/unittests/test_systems.gd
@@ -41,7 +41,6 @@ func test_stuff():
 	assert_eq(bools.a, true)
 	assert_eq(bools.b, true)
 
-
 #endregion
 
 #region Components


### PR DESCRIPTION
- Allow setting float and int members with either floats or ints
- `GFEntity.get()` now returns the Variant of a member directly if the struct only has one member
- Various bug fixes