### PR TITLE
[Feature] Add `GFEntity.get()` default value

### DIFF
--- a/cpp/src/doc_classes/GFComponent.xml
+++ b/cpp/src/doc_classes/GFComponent.xml
@@ -23,9 +23,10 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="add" qualifiers="const vararg">
+		<method name="add">
 			<return type="GFComponent" />
 			<param index="0" name="component" type="Variant" />
+			<param index="1" name="second" type="Variant" default="null" />
 			<description>
 				Overrides [method GFEntity.add].
 			</description>
@@ -37,43 +38,11 @@
 				Overrides [method GFEntity.add_child].
 			</description>
 		</method>
-		<method name="add_pair" qualifiers="const vararg">
-			<return type="GFComponent" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_pair].
-			</description>
-		</method>
-		<method name="add_pairv">
-			<return type="GFComponent" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.add_pairv].
-			</description>
-		</method>
 		<method name="add_sibling">
 			<return type="GFComponent" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Overrides [method GFEntity.add_sibling].
-			</description>
-		</method>
-		<method name="add_tag">
-			<return type="GFComponent" />
-			<param index="0" name="tag" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_tag].
-			</description>
-		</method>
-		<method name="addv">
-			<return type="GFComponent" />
-			<param index="0" name="component" type="Variant" />
-			<param index="1" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.addv].
 			</description>
 		</method>
 		<method name="clear">
@@ -197,23 +166,6 @@
 				Overrides [method GFEntity.set_name].
 			</description>
 		</method>
-		<method name="set_pair" qualifiers="const vararg">
-			<return type="GFComponent" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.set_pair].
-			</description>
-		</method>
-		<method name="set_pairv">
-			<return type="GFComponent" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" />
-			<description>
-				Overrides [method GFEntity.set_pairv].
-			</description>
-		</method>
 		<method name="set_parent">
 			<return type="GFComponent" />
 			<param index="0" name="entity" type="Variant" />
@@ -242,6 +194,13 @@
 			<param index="1" name="value" type="Variant" />
 			<description>
 				Sets the value of a component's member without triggering the [code]OnSet[/code] event. For most cases [method setm] should be preferred.
+			</description>
+		</method>
+		<method name="setp" qualifiers="const vararg">
+			<return type="GFComponent" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<description>
 			</description>
 		</method>
 		<method name="setv">

--- a/cpp/src/doc_classes/GFEntity.xml
+++ b/cpp/src/doc_classes/GFEntity.xml
@@ -9,9 +9,10 @@
 		<link title="More on Flecs Entities">https://www.flecs.dev/flecs/md_docs_2EntitiesComponents.html</link>
 	</tutorials>
 	<methods>
-		<method name="add" qualifiers="const vararg">
+		<method name="add">
 			<return type="GFEntity" />
 			<param index="0" name="component" type="Variant" />
+			<param index="1" name="second" type="Variant" default="null" />
 			<description>
 				Adds component data of type [param component] to this entity. The members of the component data are set by additional arguments after [param component].
 				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
@@ -45,37 +46,6 @@
 				This method returns [code]self[/code] for chaining.
 			</description>
 		</method>
-		<method name="add_pair" qualifiers="const vararg">
-			<return type="GFEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Adds component data to the pair of [param first] and [param second] to this entity. If the pair contains data, the members of the data are set by additional arguments after [param second].
-				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
-				[codeblock]
-				var entity:= GFEntity.new()
-				entity.add_pair(GFPosition2D, Vector2(10, 10))
-				entity.get_pair(GFPosition2D).get_vec() == Vector2(10, 10) # true
-				[/codeblock]
-				This method returns [code]self[/code] for chaining.
-			</description>
-		</method>
-		<method name="add_pairv">
-			<return type="GFEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Array" default="[]" />
-			<description>
-				Adds component data to the pair of [param first] and [param second] to this entity. If the pair contains data, the members of the data are set using [param members].
-				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
-				[codeblock]
-				var entity:= GFEntity.new()
-				entity.add_pairv(GFPosition2D, [Vector2(10, 10)])
-				entity.get_pair(GFPosition2D).get_vec() == Vector2(10, 10) # true
-				[/codeblock]
-				This method returns [code]self[/code] for chaining.
-			</description>
-		</method>
 		<method name="add_sibling">
 			<return type="GFEntity" />
 			<param index="0" name="entity" type="Variant" />
@@ -83,34 +53,6 @@
 				Adds an entity as a child to this one's parent.
 				Equivalent to calling [code]get_parent().add_child(entity)[/code].
 				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
-				This method returns [code]self[/code] for chaining.
-			</description>
-		</method>
-		<method name="add_tag">
-			<return type="GFEntity" />
-			<param index="0" name="tag" type="Variant" />
-			<description>
-				Adds a tag to this entity.
-				[codeblock]
-				var carnivore:= GFEntity.new().set_name("Carnivore")
-				var tiger:= GFEntity.new().set_name("Tiger")
-
-				tiger.add_tag(carnivore)
-				[/codeblock]
-			</description>
-		</method>
-		<method name="addv">
-			<return type="GFEntity" />
-			<param index="0" name="component" type="Variant" />
-			<param index="1" name="members" type="Array" default="[]" />
-			<description>
-				Adds component data of type [param component] to this entity. The members of the component data are set using [param members].
-				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
-				[codeblock]
-				var entity:= GFEntity.new()
-				entity.addv(GFPosition2D, [Vector2(10, 10)])
-				entity.get(GFPosition2D) == Vector2(10, 10) # true
-				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>
 		</method>
@@ -180,8 +122,9 @@
 		</method>
 		<method name="get" qualifiers="const">
 			<return type="Variant" />
-			<param index="0" name="entity" type="Variant" />
+			<param index="0" name="component" type="Variant" />
 			<param index="1" name="second" type="Variant" default="null" />
+			<param index="2" name="default_value" type="Variant" default="null" />
 			<description>
 				Returns either a reference to this entity's component's data or returns the data directly.
 				If the component is a primitive, or only has a single member, then the primitive, or the single member, will be returned as a Variant. In all other cases, a [GFComponent] is returned and [method GFComponent.getm] can be used to retrieve the member you need.
@@ -190,6 +133,17 @@
 				var entity:= GFEntity.new()
 				entity.add("glecs/meta/int")
 				entity.get("glecs/meta/int") == 0 # true
+				[/codeblock]
+				You can pass in two entities to get a pair:
+				[codeblock]
+				var entity:= GFEntity.new()
+				entity.add(DistanceTo, Target)
+				entity.get(DistanceTo, Target) != null # true
+				[/codeblock]
+				You can also specify a default value to be returned if component is not added to the entity:
+				[codeblock]
+				var entity:= GFEntity.new()
+				entity.get("glecs/meta/int", null, 25) == 25 # true
 				[/codeblock]
 			</description>
 		</method>
@@ -479,41 +433,6 @@
 				This method returns [code]self[/code] for chaining.
 			</description>
 		</method>
-		<method name="set_pair" qualifiers="const vararg">
-			<return type="GFEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Sets the component of the pair of [param first] and [param second] in this entity. The members of the component data are set by additional arguments after [param second].
-				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
-				[codeblock]
-				var start:= GFEntity.new().set_name("Start")
-				var entity:= GFEntity.new()
-				# Pair will be added if it is not already.
-				entity.set_pair(start, GFPosition2D, Vector2(10, 10))
-				entity.get_pair(start, GFPosition2D).get_vec() == Vector2(10, 10) # true
-				[/codeblock]
-				This method returns [code]self[/code] for chaining.
-			</description>
-		</method>
-		<method name="set_pairv">
-			<return type="GFEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Array" />
-			<description>
-				Sets the component of the pair of [param first] and [param second] in this entity. The members of the component data are set by [param members].
-				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
-				[codeblock]
-				var start:= GFEntity.new().set_name("Start")
-				var entity:= GFEntity.new()
-				# Pair will be added if it is not already.
-				entity.set_pairv(start, GFPosition2D, [Vector2(10, 10)])
-				entity.get_pair(start, GFPosition2D).get_vec() == Vector2(10, 10) # true
-				[/codeblock]
-				This method returns [code]self[/code] for chaining.
-			</description>
-		</method>
 		<method name="set_parent">
 			<return type="GFEntity" />
 			<param index="0" name="entity" type="Variant" />
@@ -530,6 +449,41 @@
 				    .set_name("Child") \
 				    .set_parent(par)
 				par.has_child("Child") # true
+				[/codeblock]
+				This method returns [code]self[/code] for chaining.
+			</description>
+		</method>
+		<method name="setp" qualifiers="const vararg">
+			<return type="GFEntity" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<description>
+				Sets the component of the pair of [param first] and [param second] in this entity. The members of the component data are set by additional arguments after [param second].
+				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
+				[codeblock]
+				var start:= GFEntity.new().set_name("Start")
+				var entity:= GFEntity.new()
+				# Pair will be added if it is not already.
+				entity.set_pair(start, GFPosition2D, Vector2(10, 10))
+				entity.get_pair(start, GFPosition2D).get_vec() == Vector2(10, 10) # true
+				[/codeblock]
+				This method returns [code]self[/code] for chaining.
+			</description>
+		</method>
+		<method name="setpv">
+			<return type="GFEntity" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<param index="2" name="members" type="Array" />
+			<description>
+				Sets the component of the pair of [param first] and [param second] in this entity. The members of the component data are set by [param members].
+				The component's type ID is coerced from a [Variant]. To learn more about [Variant] coercion see [method GFWorld.coerce_id].
+				[codeblock]
+				var start:= GFEntity.new().set_name("Start")
+				var entity:= GFEntity.new()
+				# Pair will be added if it is not already.
+				entity.set_pairv(start, GFPosition2D, [Vector2(10, 10)])
+				entity.get_pair(start, GFPosition2D).get_vec() == Vector2(10, 10) # true
 				[/codeblock]
 				This method returns [code]self[/code] for chaining.
 			</description>

--- a/cpp/src/doc_classes/GFModule.xml
+++ b/cpp/src/doc_classes/GFModule.xml
@@ -7,9 +7,10 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="add" qualifiers="const vararg">
+		<method name="add">
 			<return type="GFModule" />
 			<param index="0" name="component" type="Variant" />
+			<param index="1" name="second" type="Variant" default="null" />
 			<description>
 				Overrides [GFEntity.add].
 			</description>
@@ -21,43 +22,11 @@
 				Overrides [GFEntity.add_child].
 			</description>
 		</method>
-		<method name="add_pair" qualifiers="const vararg">
-			<return type="GFModule" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_pair].
-			</description>
-		</method>
-		<method name="add_pairv">
-			<return type="GFModule" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.add_pairv].
-			</description>
-		</method>
 		<method name="add_sibling">
 			<return type="GFModule" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Overrides [GFEntity.add_sibling].
-			</description>
-		</method>
-		<method name="add_tag">
-			<return type="GFModule" />
-			<param index="0" name="tag" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_tag].
-			</description>
-		</method>
-		<method name="addv">
-			<return type="GFModule" />
-			<param index="0" name="component" type="Variant" />
-			<param index="1" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.addv].
 			</description>
 		</method>
 		<method name="clear">
@@ -135,28 +104,18 @@
 				Overrides [method GFEntity.set_name].
 			</description>
 		</method>
-		<method name="set_pair" qualifiers="const vararg">
-			<return type="GFModule" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.set_pair].
-			</description>
-		</method>
-		<method name="set_pairv">
-			<return type="GFModule" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" />
-			<description>
-				Overrides [method GFEntity.set_pairv].
-			</description>
-		</method>
 		<method name="set_parent">
 			<return type="GFModule" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Overrides [method GFEntity.set_parent].
+			</description>
+		</method>
+		<method name="setp" qualifiers="const vararg">
+			<return type="GFModule" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<description>
 			</description>
 		</method>
 		<method name="setv">

--- a/cpp/src/doc_classes/GFPair.xml
+++ b/cpp/src/doc_classes/GFPair.xml
@@ -9,9 +9,10 @@
 		<link title="More on Flecs Pairs">https://www.flecs.dev/flecs/md_docs_2Relationships</link>
 	</tutorials>
 	<methods>
-		<method name="add" qualifiers="const vararg">
+		<method name="add">
 			<return type="GFPair" />
 			<param index="0" name="component" type="Variant" />
+			<param index="1" name="second" type="Variant" default="null" />
 			<description>
 				Overrides [method GFEntity.add].
 			</description>
@@ -23,43 +24,11 @@
 				Overrides [method GFEntity.add_child].
 			</description>
 		</method>
-		<method name="add_pair" qualifiers="const vararg">
-			<return type="GFPair" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_pair].
-			</description>
-		</method>
-		<method name="add_pairv">
-			<return type="GFPair" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.add_pairv].
-			</description>
-		</method>
 		<method name="add_sibling">
 			<return type="GFPair" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Overrides [method GFEntity.add_sibling].
-			</description>
-		</method>
-		<method name="add_tag">
-			<return type="GFPair" />
-			<param index="0" name="tag" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_tag].
-			</description>
-		</method>
-		<method name="addv">
-			<return type="GFPair" />
-			<param index="0" name="component" type="Variant" />
-			<param index="1" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.addv].
 			</description>
 		</method>
 		<method name="clear">
@@ -190,28 +159,18 @@
 				Overrides [method GFEntity.set_name].
 			</description>
 		</method>
-		<method name="set_pair" qualifiers="const vararg">
-			<return type="GFPair" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.set_pair].
-			</description>
-		</method>
-		<method name="set_pairv">
-			<return type="GFPair" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" />
-			<description>
-				Overrides [method GFEntity.set_pairv].
-			</description>
-		</method>
 		<method name="set_parent">
 			<return type="GFPair" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Overrides [method GFEntity.set_parent].
+			</description>
+		</method>
+		<method name="setp" qualifiers="const vararg">
+			<return type="GFPair" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<description>
 			</description>
 		</method>
 		<method name="setv">

--- a/cpp/src/doc_classes/GFRegisterableEntity.xml
+++ b/cpp/src/doc_classes/GFRegisterableEntity.xml
@@ -21,9 +21,10 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="add" qualifiers="const vararg">
+		<method name="add">
 			<return type="GFRegisterableEntity" />
 			<param index="0" name="component" type="Variant" />
+			<param index="1" name="second" type="Variant" default="null" />
 			<description>
 			</description>
 		</method>
@@ -33,37 +34,9 @@
 			<description>
 			</description>
 		</method>
-		<method name="add_pair" qualifiers="const vararg">
-			<return type="GFRegisterableEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-			</description>
-		</method>
-		<method name="add_pairv">
-			<return type="GFRegisterableEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" default="[]" />
-			<description>
-			</description>
-		</method>
 		<method name="add_sibling">
 			<return type="GFRegisterableEntity" />
 			<param index="0" name="entity" type="Variant" />
-			<description>
-			</description>
-		</method>
-		<method name="add_tag">
-			<return type="GFRegisterableEntity" />
-			<param index="0" name="tag" type="Variant" />
-			<description>
-			</description>
-		</method>
-		<method name="addv">
-			<return type="GFRegisterableEntity" />
-			<param index="0" name="component" type="Variant" />
-			<param index="1" name="members" type="Variant" default="[]" />
 			<description>
 			</description>
 		</method>
@@ -112,24 +85,16 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_pair" qualifiers="const vararg">
-			<return type="GFRegisterableEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-			</description>
-		</method>
-		<method name="set_pairv">
-			<return type="GFRegisterableEntity" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" />
-			<description>
-			</description>
-		</method>
 		<method name="set_parent">
 			<return type="GFRegisterableEntity" />
 			<param index="0" name="entity" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="setp" qualifiers="const vararg">
+			<return type="GFRegisterableEntity" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
 			<description>
 			</description>
 		</method>

--- a/cpp/src/doc_classes/GFTag.xml
+++ b/cpp/src/doc_classes/GFTag.xml
@@ -10,9 +10,10 @@
 		<link title="More on Flecs Tags">https://www.flecs.dev/flecs/md_docs_2Quickstart.html#tag</link>
 	</tutorials>
 	<methods>
-		<method name="add" qualifiers="const vararg">
+		<method name="add">
 			<return type="GFTag" />
 			<param index="0" name="component" type="Variant" />
+			<param index="1" name="second" type="Variant" default="null" />
 			<description>
 				Overrides [method GFEntity.add].
 			</description>
@@ -24,43 +25,11 @@
 				Overrides [method GFEntity.add_child].
 			</description>
 		</method>
-		<method name="add_pair" qualifiers="const vararg">
-			<return type="GFTag" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_pair].
-			</description>
-		</method>
-		<method name="add_pairv">
-			<return type="GFTag" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.add_pairv].
-			</description>
-		</method>
 		<method name="add_sibling">
 			<return type="GFTag" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Overrides [method GFEntity.add_sibling].
-			</description>
-		</method>
-		<method name="add_tag">
-			<return type="GFTag" />
-			<param index="0" name="tag" type="Variant" />
-			<description>
-				Overrides [method GFEntity.add_tag].
-			</description>
-		</method>
-		<method name="addv">
-			<return type="GFTag" />
-			<param index="0" name="component" type="Variant" />
-			<param index="1" name="members" type="Variant" default="[]" />
-			<description>
-				Overrides [method GFEntity.addv].
 			</description>
 		</method>
 		<method name="clear">
@@ -142,28 +111,18 @@
 				Ovverrides [method GFEntity.set_name].
 			</description>
 		</method>
-		<method name="set_pair" qualifiers="const vararg">
-			<return type="GFTag" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<description>
-				Ovverrides [method GFEntity.set_pair].
-			</description>
-		</method>
-		<method name="set_pairv">
-			<return type="GFTag" />
-			<param index="0" name="first" type="Variant" />
-			<param index="1" name="second" type="Variant" />
-			<param index="2" name="members" type="Variant" />
-			<description>
-				Ovverrides [method GFEntity.set_pairv].
-			</description>
-		</method>
 		<method name="set_parent">
 			<return type="GFTag" />
 			<param index="0" name="entity" type="Variant" />
 			<description>
 				Ovverrides [method GFEntity.set_parent].
+			</description>
+		</method>
+		<method name="setp" qualifiers="const vararg">
+			<return type="GFTag" />
+			<param index="0" name="first" type="Variant" />
+			<param index="1" name="second" type="Variant" />
+			<description>
 			</description>
 		</method>
 		<method name="setv">

--- a/cpp/src/entity.cpp
+++ b/cpp/src/entity.cpp
@@ -375,17 +375,17 @@ Ref<GFEntity> GFEntity::emit(
 	return Ref(this);
 }
 
-Variant GFEntity::get_component(const Variant entity, const Variant second) const {
+Variant GFEntity::get_component(const Variant entity, const Variant second, const Variant default_value) const {
 	GFWorld* w = get_world();
 
 	ecs_entity_t comp_id = w->coerce_id(entity);
-	CHECK_ENTITY_ALIVE(comp_id, w, nullptr,
+	CHECK_ENTITY_ALIVE(comp_id, w, default_value,
 		"Failed to get component\n"
 	);
 
 	if (second.booleanize()) {
 		ecs_entity_t second_id = w->coerce_id(second);
-		CHECK_ENTITY_ALIVE(second_id, w, nullptr,
+		CHECK_ENTITY_ALIVE(second_id, w, default_value,
 			"Failed to get component\n"
 		);
 
@@ -393,7 +393,7 @@ Variant GFEntity::get_component(const Variant entity, const Variant second) cons
 	}
 
 	if (!ecs_has_id(get_world()->raw(), get_id(), comp_id)) {
-		ERR(nullptr,
+		ERR(default_value,
 			"Failed to get component\n	Could not find attached component ID: ",
 			w->id_to_text(comp_id),
 			" on entity: ",
@@ -782,7 +782,7 @@ void GFEntity::_bind_methods() {
 	godot::ClassDB::bind_static_method(GFEntity::get_class_static(), D_METHOD("from_id", "id", "world"), &GFEntity::from_id, nullptr);
 
 	godot::ClassDB::bind_method(D_METHOD("_get", "property"), &GFEntity::__get);
-	godot::ClassDB::bind_method(D_METHOD("get", "entity", "second"), &GFEntity::get_component, nullptr);
+	godot::ClassDB::bind_method(D_METHOD("get", "component", "second", "default_value"), &GFEntity::get_component, nullptr, nullptr);
 
 	godot::ClassDB::bind_method(D_METHOD("delete"), &GFEntity::delete_);
 

--- a/cpp/src/entity.cpp
+++ b/cpp/src/entity.cpp
@@ -210,89 +210,24 @@ Ref<GFEntity> GFEntity::add_child(const Variant entity) {
 	return Ref(this);
 }
 
-Ref<GFEntity> GFEntity::add_component(
-	const Variant** args, GDExtensionInt arg_count, GDExtensionCallError &error
-) {
-	if (arg_count < 1) {
-		// Too few arguments, return with error.
-		error.error = GDExtensionCallErrorType::GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
-		error.argument = arg_count;
-		error.expected = 1;
-		return Ref(this);
-	}
-
-	// Parse arguments
-	Array members = Array();
-	members.resize(arg_count);
-	for (int i=0; i != arg_count; i++) {
-		members[i] = *args[i];
-	}
-	Variant comopnent = members.pop_front();
-
-	add_componentv(comopnent, members);
-
-	return Ref(this);
-}
-
-Ref<GFEntity> GFEntity::add_componentv(const Variant component, const Array members) {
+Ref<GFEntity> GFEntity::add_component(const Variant component, const Variant second) {
 	GFWorld* w = get_world();
 
-	ecs_entity_t c_id = w->coerce_id(component);
-	CHECK_ENTITY_ALIVE(c_id, w, nullptr,
-		"Failed to add to component\n"
+	ecs_entity_t comp_id = w->coerce_id(component);
+	CHECK_ENTITY_ALIVE(comp_id, w, Ref(this),
+		"Failed to add component\n"
 	);
 
-	ecs_add_id(w->raw(), get_id(), c_id);
+	if (second.booleanize()) {
+		ecs_entity_t second_id = w->coerce_id(second);
+		CHECK_ENTITY_ALIVE(second_id, w, Ref(this),
+			"Failed to add component\n"
+		);
 
-	if (members.size() != 0) {
-		return set_componentv(c_id, members);
+		comp_id = ecs_pair(comp_id, second_id);
 	}
 
-	return Ref(this);
-}
-
-Ref<GFEntity> GFEntity::add_pair(
-	const Variant** args, GDExtensionInt arg_count, GDExtensionCallError &error
-) {
-	if (arg_count < 2) {
-		// Too few arguments, return with error.
-		error.error = GDExtensionCallErrorType::GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;
-		error.argument = arg_count;
-		error.expected = 2;
-		return Ref(this);
-	}
-
-	// Parse arguments
-	Array members = Array();
-	members.resize(arg_count);
-	for (int i=0; i != arg_count; i++) {
-		members[i] = *args[i];
-	}
-	Variant first = members.pop_front();
-	Variant sec = members.pop_front();
-
-	return add_pairv(first, sec, members);
-}
-Ref<GFEntity> GFEntity::add_pairv(
-	const Variant first,
-	const Variant second,
-	const Array members
-) {
-	GFWorld* w = get_world();
-
-	ecs_entity_t first_id = w->coerce_id(first);
-	ecs_entity_t second_id = w->coerce_id(second);
-	ecs_entity_t pair_id = w->pair_ids(first_id, second_id);
-	if (
-		members.size() != 0
-		|| ecs_has_id(w->raw(), pair_id, FLECS_IDEcsComponentID_)
-	) {
-		// Add pair as a component
-		return add_componentv(pair_id, members);
-	} else {
-		// Add pair as a dataless tag
-		return add_tag(pair_id);
-	}
+	ecs_add_id(w->raw(), get_id(), comp_id);
 
 	return Ref(this);
 }
@@ -312,25 +247,6 @@ Ref<GFEntity> GFEntity::add_sibling(const Variant sib) {
 	ecs_add_pair(w->raw(), sib_id, EcsChildOf, parent);
 
 	return this;
-}
-
-
-Ref<GFEntity> GFEntity::add_tag(const Variant tag) {
-	GFWorld* w = get_world();
-
-	ecs_entity_t tag_id = w->coerce_id(tag);
-
-	if (ecs_has(w->raw(), tag_id, EcsComponent)) {
-		ERR(nullptr,
-			"Failed to add tag to entity\n",
-			"	ID, ", tag_id, " is a component, not a tag\n"
-			"	(Tags are any entity with no data)"
-		);
-	}
-
-	ecs_add_id(w->raw(), get_id(), tag_id);
-
-	return Ref(this);
 }
 
 Ref<GFEntity> GFEntity::emit(
@@ -573,10 +489,10 @@ Ref<GFEntity> GFEntity::set_pairv (
 	const Array members
 ) {
 	ecs_entity_t first_id = get_world()->coerce_id(first);
-	ecs_entity_t second_id = get_world()->coerce_id(second);
-	set_componentv(ecs_pair(first_id, second_id), members);
-
-	return Ref(this);
+	if (second.booleanize()) {
+		first_id = ecs_pair(first_id, get_world()->coerce_id(second));
+	}
+	return set_componentv(first_id, members);
 }
 
 Ref<GFEntity> GFEntity::clear() {
@@ -603,7 +519,7 @@ GFWorld* GFEntity::get_world() const { return Object::cast_to<GFWorld>(
 ); }
 
 Ref<GFEntity> GFEntity::inherit(Variant entity) {
-	return add_pairv(EcsIsA, entity, {});
+	return add_component(EcsIsA, entity);
 }
 
 bool GFEntity::is_alive() const {

--- a/cpp/src/entity.h
+++ b/cpp/src/entity.h
@@ -20,44 +20,30 @@
 #define OVERRIDE_ENTITY_SELF_METHODS(Self)	\
 	Ref<Self> add_child(const Variant v0)	{ return GFEntity::add_child(v0); }	\
 	Ref<Self> add_sibling(const Variant v0)	{ return GFEntity::add_sibling(v0); }	\
-	Ref<Self> add_componentv(const Variant v0, const Variant v1)	{ return GFEntity::add_componentv(v0, v1); }	\
+	Ref<Self> add_component(const Variant v0, const Variant v1)	{ return GFEntity::add_component(v0, v1); }	\
 	Ref<Self> clear()	{ return GFEntity::clear(); }	\
 	Ref<Self> set_componentv(const Variant v0, const Variant v1)	{ return GFEntity::set_componentv(v0, v1); }	\
-	Ref<Self> set_pairv(const Variant v0, const Variant v1, const Variant v2)	{ return GFEntity::set_pairv(v0, v1, v2); }	\
-	Ref<Self> add_pairv(const Variant v0, const Variant v1, const Variant v2)	{ return GFEntity::add_pairv(v0, v1, v2); }	\
-	Ref<Self> add_tag(const Variant v0)	{ return GFEntity::add_tag(v0); }	\
 	Ref<Self> emit(const Variant v0, const Array v1)	{ return GFEntity::emit(v0, v1); }	\
 	Ref<Self> inherit(const Variant v0)	{ return GFEntity::inherit(v0); }	\
 	Ref<Self> set_name(const String v0)	{ return GFEntity::set_name(v0); }	\
 	Ref<Self> set_parent(const Variant v0)	{ return GFEntity::set_parent(v0); }	\
-	Ref<Self> add_component(const Variant** v0, GDExtensionInt v1, GDExtensionCallError& v2)	{ return GFEntity::add_component(v0, v1, v2); }	\
 	Ref<Self> set_component(const Variant** v0, GDExtensionInt v1, GDExtensionCallError& v2)	{ return GFEntity::set_component(v0, v1, v2); }	\
-	Ref<Self> add_pair(const Variant** v0, GDExtensionInt v1, GDExtensionCallError& v2)	{ return GFEntity::add_pair(v0, v1, v2); }	\
 	Ref<Self> set_pair(const Variant** v0, GDExtensionInt v1, GDExtensionCallError& v2)	{ return GFEntity::set_pair(v0, v1, v2); }	\
 	Ref<Self> remove_component(const Variant v0, const Variant v1)	{ return GFEntity::remove_component(v0, v1); }	\
 ;
 
 #define REGISTER_ENTITY_SELF_METHODS(Self)	\
+	godot::ClassDB::bind_method(D_METHOD("add", "component", "second"),	&Self::add_component, nullptr);	\
 	godot::ClassDB::bind_method(D_METHOD("add_child", "entity"),	&Self::add_child);	\
 	godot::ClassDB::bind_method(D_METHOD("add_sibling", "entity"),	&Self::add_sibling);	\
-	godot::ClassDB::bind_method(D_METHOD("addv", "component", "members"),	&Self::add_componentv, Array());	\
 	godot::ClassDB::bind_method(D_METHOD("clear"),	&Self::clear);	\
 	godot::ClassDB::bind_method(D_METHOD("setv", "component", "members"),	&Self::set_componentv);	\
-	godot::ClassDB::bind_method(D_METHOD("add_pairv", "first", "second", "members"),	&Self::add_pairv, Array());	\
-	godot::ClassDB::bind_method(D_METHOD("set_pairv", "first", "second", "members"),	&Self::set_pairv);	\
-	godot::ClassDB::bind_method(D_METHOD("add_tag", "tag"),	&Self::add_tag);	\
+	godot::ClassDB::bind_method(D_METHOD("setpv", "first", "second", "members"),	&Self::set_pairv);	\
 	godot::ClassDB::bind_method(D_METHOD("emit", "entity", "event_members"),	&Self::emit, Array());	\
 	godot::ClassDB::bind_method(D_METHOD("inherit", "entity"),	&Self::inherit);	\
 	godot::ClassDB::bind_method(D_METHOD("remove", "entity", "second"),	&Self::remove_component, nullptr);	\
 	godot::ClassDB::bind_method(D_METHOD("set_name", "name"),	&Self::set_name);	\
 	godot::ClassDB::bind_method(D_METHOD("set_parent", "entity"),	&Self::set_parent);	\
-	{	\
-		MethodInfo mi;	\
-		mi.arguments.push_back(PropertyInfo(Variant::NIL, "component"));	\
-		mi.name = "add";	\
-		mi.flags = METHOD_FLAGS_DEFAULT;	\
-		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName(mi.name), &Self::add_component, mi);	\
-	}	\
 	{	\
 		MethodInfo mi;	\
 		mi.arguments.push_back(PropertyInfo(Variant::NIL, "component"));	\
@@ -68,14 +54,7 @@
 		MethodInfo mi;	\
 		mi.arguments.push_back(PropertyInfo(Variant::NIL, "first"));	\
 		mi.arguments.push_back(PropertyInfo(Variant::NIL, "second"));	\
-		mi.name = "add_pair";	\
-		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName(mi.name), &Self::add_pair, mi);	\
-	}	\
-	{	\
-		MethodInfo mi;	\
-		mi.arguments.push_back(PropertyInfo(Variant::NIL, "first"));	\
-		mi.arguments.push_back(PropertyInfo(Variant::NIL, "second"));	\
-		mi.name = "set_pair";	\
+		mi.name = "setp";	\
 		godot::ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, StringName(mi.name), &Self::set_pair, mi);	\
 	}	\
 ;
@@ -123,19 +102,15 @@ namespace godot {
 		bool _set(StringName, Variant);
 
 		Ref<GFEntity> add_child(const Variant entity);
-		Ref<GFEntity> add_component(const Variant**, GDExtensionInt, GDExtensionCallError&);
-		Ref<GFEntity> add_componentv(const Variant, const Array);
+		Ref<GFEntity> add_component(const Variant, const Variant);
 		Ref<GFEntity> set_component(const Variant**, GDExtensionInt, GDExtensionCallError&);
 		Ref<GFEntity> set_componentv(const Variant, const Array);
 
-		Ref<GFEntity> add_pair(const Variant**, GDExtensionInt, GDExtensionCallError&);
-		Ref<GFEntity> add_pairv(const Variant, const Variant, const Array);
 		Ref<GFEntity> set_pair(const Variant**, GDExtensionInt, GDExtensionCallError&);
 		Ref<GFEntity> set_pairv(const Variant, const Variant, const Array);
 
 		Ref<GFEntity> add_sibling(const Variant);
 
-		Ref<GFEntity> add_tag(const Variant);
 		Ref<GFEntity> emit(const Variant, const Array);
 		Ref<GFEntity> set_name(const String);
 		Ref<GFEntity> set_parent(const Variant entity);

--- a/cpp/src/entity.h
+++ b/cpp/src/entity.h
@@ -145,7 +145,7 @@ namespace godot {
 
 		Ref<GFEntity> get_child(const String) const;
 		TypedArray<GFEntity> get_children() const;
-		Variant get_component(const Variant, const Variant) const;
+		Variant get_component(const Variant, const Variant, const Variant) const;
 		static const RegEx* get_entity_id_regex();
 		ecs_entity_t get_id() const;
 		String get_name() const;

--- a/examples/asteroids/asteroids.gd
+++ b/examples/asteroids/asteroids.gd
@@ -12,11 +12,8 @@ func _ready() -> void:
 	e.set_name("Test")
 	e.add(GFCanvasItem)
 	e.add(GFColorRect)
-	e.add(GFRotation2D)
-	e.add(GFSkew2D)
-	e.set(GFScale2D, Vector2.ONE)
-	e.set(GFCanvasItem.material, $ColorRect.material)
 	e.set(GFColorRect.size, Vector2(100, 22))
+	e.set(GFColorRect.color, Color.RED)
 
 	c = GFEntity.new().set_name("Child") \
 		.set_parent(e) \
@@ -34,14 +31,16 @@ func _process(delta: float) -> void:
 	
 	if Input.get_axis("ui_left", "ui_right"):
 		e.set(GFRotation2D,
-			e.get(GFRotation2D)
+			e.get(GFRotation2D, 0, 0.0)
 			+ (delta * Input.get_axis("ui_left", "ui_right")),
 			)
 
 	var v_axis:= Input.get_axis("ui_up", "ui_down")
 	if v_axis:
-		var size_c:GFColorRect.size = e.get(GFColorRect.size)
-		size_c.set_y(size_c.get_y() - (100 * delta * v_axis))
+		e.set(GFColorRect.size,
+			e.get(GFColorRect.size, 0 ,Vector2.ZERO)
+			- Vector2(0, 100 * delta * v_axis),
+			)
 
 	if Input.is_action_just_pressed("ui_text_delete"):
 		if e.has(GFCanvasItem.hidden):
@@ -66,7 +65,7 @@ func _process(delta: float) -> void:
 		c.set(GFColorRect.color, Color(randf(), randf(), randf()))
 	
 	e.set(GFSkew2D,
-		e.get(GFSkew2D)
+		e.get(GFSkew2D, 0, 0.0)
 		+ (int(Input.is_key_pressed(KEY_6)) - int(Input.is_key_pressed(KEY_5)))
 		* delta
 		)

--- a/gd/rendering/color_rect.gd
+++ b/gd/rendering/color_rect.gd
@@ -2,7 +2,7 @@
 class_name GFColorRect extends GFTag
 
 func _register(world:GFWorld) -> void:
-	add_pair("/root/flecs/core/With", GFCanvasItem)
+	add("/root/flecs/core/With", GFCanvasItem)
 	world.register_script(color).set_name("Color")
 	world.register_script(size).set_name("Size")
 

--- a/unittests/test_components.gd
+++ b/unittests/test_components.gd
@@ -91,7 +91,7 @@ func test_components_in_relationships():
 	var w:= GFWorld.new()
 
 	var e:= GFEntity.new_in_world(w)
-	var foo:Foo = e.add_pair(Targets, Foo) \
+	var foo:Foo = e.add(Targets, Foo) \
 		.get(w.pair(Targets, Foo))
 
 	foo.set_value(Vector2(54, 6))

--- a/unittests/test_components.gd
+++ b/unittests/test_components.gd
@@ -131,13 +131,6 @@ func test_primitive():
 	e.add(Int)
 	e.set(Int, 25)
 	assert_eq(e.get(Int), 25)
-	
-	e.add(array)
-	e.set(array, [2, 3])
-	var arr = e.get(array)
-	assert_eq(arr.size(), 2)
-	assert_eq(arr[0], 2)
-	assert_eq(arr[1], 3)
 
 
 class Targets extends GFRegisterableEntity: pass

--- a/unittests/test_entities.gd
+++ b/unittests/test_entities.gd
@@ -196,8 +196,8 @@ func test_get_children():
 func test_remove():
 	var e:= GFEntity.new() \
 		.set_name("RemovingFrom") \
-		.add(Foo, 2.24) \
-		.add_pair(Foo, Stringy, 234.1)
+		.set(Foo, 2.24) \
+		.setp(Foo, Stringy, 234.1)
 
 	assert_true(e.has(Foo), "Expected RemovingFrom to have (Foo, Stringy)")
 	assert_almost_eq(e.get(Foo), 2.24, 0.01)
@@ -291,8 +291,8 @@ func test_inheritance_doc_example():
 func test_get_target_for():
 	var enterprise:= GFEntity.new() \
 		.set_name("Enterprise") \
-		.add_pair(GFPosition2D, GFScale2D) \
-		.add_pair(GFPosition2D, GFRotation2D)
+		.add(GFPosition2D, GFScale2D) \
+		.add(GFPosition2D, GFRotation2D)
 
 	var targets:= []
 	var i:= 0

--- a/unittests/test_events.gd
+++ b/unittests/test_events.gd
@@ -55,7 +55,7 @@ func test_on_set_event():
 			)
 
 	var e:= GFEntity.new() \
-		.add(Ints, 2, 31) \
+		.set(Ints, 2, 31) \
 		.set_name("WithInts")
 	var e2:= GFEntity.new() \
 		.set_name("WithoutInts")
@@ -64,7 +64,7 @@ func test_on_set_event():
 	var e4:= GFEntity.new() \
 		.set_name("WithoutInts")
 
-	e3.add(Ints, 99, 2)
+	e3.set(Ints, 99, 2)
 
 	assert_eq(data.i, 2 + 31 + 99 + 2)
 
@@ -96,7 +96,7 @@ func test_on_add_event_with_objects():
 	data.i = 0
 	var e2:= GFEntity.new() \
 		.set_name("WithTextures")
-	e2.add(Textures, load("res://icon.png"))
+	e2.set(Textures, load("res://icon.png"))
 	assert_eq(data.i, 1)
 	assert_eq(e2.get(Textures), load("res://icon.png"))
 

--- a/unittests/test_prefab.gd
+++ b/unittests/test_prefab.gd
@@ -33,7 +33,7 @@ func test_prefab():
 	var isa:= world.coerce_id("flecs/core/IsA")
 	var myprefab:= world.coerce_id(MyPrefab)
 	var pair:= world.pair(isa, myprefab)
-	entity.add_tag(pair)
+	entity.add(pair)
 
 	# Test inhereted components exist entity
 	var foo:Foo = entity.get(Foo)
@@ -87,8 +87,8 @@ class Bar extends GFComponent:
 
 class MyPrefab extends GFRegisterableEntity:
 	func _register(_world:GFWorld) -> void:
-		add_tag("flecs/core/Prefab")
-		add(Foo, true, 23, 2.33)
-		add(Bar, Vector2(2, 1.1), 5.6)
+		add("flecs/core/Prefab")
+		set(Foo, true, 23, 2.33)
+		set(Bar, Vector2(2, 1.1), 5.6)
 
 #endregion

--- a/unittests/test_queries.gd
+++ b/unittests/test_queries.gd
@@ -87,7 +87,7 @@ func test_up_traversal():
 	var child:= GFEntity.new() \
 		.set_name("Child") \
 		.add(Bools) \
-		.add_pair("flecs/core/ChildOf", par)
+		.add("flecs/core/ChildOf", par)
 
 	var parent_descriptions:= GFQueryBuilder.new() \
 		.with(Bools).up() \
@@ -147,10 +147,10 @@ func test_query_variable():
 	# Setup entities to query for
 	var item:= GFEntity.new() \
 		.set_name("Item3D") \
-		.add_pair(rendering, world_3d)
+		.add(rendering, world_3d)
 	var item2:= GFEntity.new() \
 		.set_name("Item2D") \
-		.add_pair(rendering, world_2d)
+		.add(rendering, world_2d)
 
 	# Run query
 	var q:= GFQueryBuilder.new() \

--- a/unittests/test_relations.gd
+++ b/unittests/test_relations.gd
@@ -21,15 +21,15 @@ func test_add_and_set_pairs() -> void:
 
 	var e:= GFEntity.new()
 
-	e.add_pair("Eats", GFRotation2D, 3.0)
+	e.setp("Eats", GFRotation2D, 3.0)
 	assert_almost_eq(
 		e.get(eats.pair(GFRotation2D)),
 		3.0,
 		0.01,
 	)
 
-	e.set_pair(eats, GFRotation2D, 3000)
-	e.add_pair(GFRotation2D, eats, 1.1)
+	e.setp(eats, GFRotation2D, 3000)
+	e.setp(GFRotation2D, eats, 1.1)
 
 	assert_almost_eq(
 		e.get(eats, GFRotation2D),
@@ -51,10 +51,10 @@ func test_basic_query():
 		.set_name("Grass")
 	var man:= GFEntity.new() \
 		.set_name("Man") \
-		.add_pair("Eats", apple)
+		.add("Eats", apple)
 	var cow:= GFEntity.new() \
 		.set_name("Cow") \
-		.add_pair("Eats", grass)
+		.add("Eats", grass)
 
 	var grass_eater_iter:= GFQueryBuilder \
 		.new() \

--- a/unittests/test_simple_systems.gd
+++ b/unittests/test_simple_systems.gd
@@ -127,7 +127,7 @@ func test_strings():
 
 	var entity:= GFEntity.new() \
 		.set_name("Test") \
-		.add(Strings, "", "po")
+		.set(Strings, "", "po")
 	var strings:Strings = entity.get(Strings)
 	assert_eq(strings.a, "")
 	assert_eq(strings.b, "po")


### PR DESCRIPTION
Adds an argument for a default value to be returned if `GFEntity.get()` could not return the requested component.

Example:
```gdscript
var entity:= GFEntity.new()
entity.get("glecs/meta/int", null, 25) == 25 # true
```

Closes #122

Also removes setting components from `GFEntity.add()`. If a component needs to be set as soon as it's added then use `GFEntity.set()`.

Also renames:
- `GFEntity.set_pair()` ->  `GFEntity.setp()`
- `GFEntity.set_pairv()` -> `GFEntity.setpv()`

Closes #121 

