### PR TITLE
[Feature] Return final entity reference when building observers and systems

### DIFF
--- a/cpp/src/doc_classes/GFObserverBuilder.xml
+++ b/cpp/src/doc_classes/GFObserverBuilder.xml
@@ -52,7 +52,7 @@
 			</description>
 		</method>
 		<method name="for_each">
-			<return type="void" />
+			<return type="GFEntity" />
 			<param index="0" name="callback" type="Callable" />
 			<description>
 				Builds the observer with a callback for iterating over each result.

--- a/cpp/src/doc_classes/GFSystemBuilder.xml
+++ b/cpp/src/doc_classes/GFSystemBuilder.xml
@@ -41,7 +41,7 @@
 			</description>
 		</method>
 		<method name="for_each">
-			<return type="void" />
+			<return type="GFEntity" />
 			<param index="0" name="callback" type="Callable" />
 			<description>
 				Builds the system with a callback for iterating over each result.

--- a/cpp/src/observer_builder.cpp
+++ b/cpp/src/observer_builder.cpp
@@ -16,7 +16,7 @@ Ref<GFObserverBuilder> GFObserverBuilder::new_in_world(GFWorld* world) {
 	return memnew(GFObserverBuilder(world));
 }
 
-void GFObserverBuilder::for_each(const Callable callable) {
+Ref<GFEntity> GFObserverBuilder::for_each(const Callable callable) {
 	QUERYLIKE_BUILD_START
 
 	ecs_entity_t obs_id = GFEntityBuilder::build_id();
@@ -35,6 +35,11 @@ void GFObserverBuilder::for_each(const Callable callable) {
 	}
 
 	QUERYLIKE_BUILD_END
+
+	return GFEntity::from_id(
+		obs_id,
+		get_world()
+	);
 }
 
 Ref<GFObserverBuilder> GFObserverBuilder::set_event(int index, const Variant event) {

--- a/cpp/src/observer_builder.h
+++ b/cpp/src/observer_builder.h
@@ -32,7 +32,7 @@ namespace godot {
 
 		static Ref<GFObserverBuilder> new_in_world(GFWorld*);
 
-		void for_each(const Callable callable);
+		Ref<GFEntity> for_each(const Callable callable);
 		Ref<GFObserverBuilder> set_events_varargs(
 			const Variant** args,
 			GDExtensionInt arg_count,

--- a/cpp/src/system_builder.cpp
+++ b/cpp/src/system_builder.cpp
@@ -19,7 +19,7 @@ Ref<GFSystemBuilder> GFSystemBuilder::new_in_world(GFWorld* world) {
 	return memnew(GFSystemBuilder(world));
 }
 
-void GFSystemBuilder::for_each(const Callable callable) {
+Ref<GFEntity> GFSystemBuilder::for_each(const Callable callable) {
 	QUERYLIKE_BUILD_START
 
 	ecs_entity_t sys_id = GFEntityBuilder::build_id();
@@ -37,6 +37,11 @@ void GFSystemBuilder::for_each(const Callable callable) {
 	}
 
 	QUERYLIKE_BUILD_END
+
+	return GFEntity::from_id(
+		sys_id,
+		get_world()
+	);
 }
 
 // **********************************************

--- a/cpp/src/system_builder.h
+++ b/cpp/src/system_builder.h
@@ -34,7 +34,7 @@ namespace godot {
 		OVERRIDE_QUERYLIKE_SELF_METHODS(GFSystemBuilder);
 
 		static Ref<GFSystemBuilder> new_in_world(GFWorld*);
-		void for_each(const Callable callable);
+		Ref<GFEntity> for_each(const Callable callable);
 
 		// **************************************
 		// *** Unexposed ***


### PR DESCRIPTION
Example:
```gdscript
var system = GFSystemBuilder.new() \
	.with("glecs/meta/int") \
	.for_each(func(x): pass) # This line now returns a GFEntity for the system

assert(is_instance_valid(system))
assert(system is GFEntity)
```

Closes: #68